### PR TITLE
Add basic e2e tests for Metal LB operator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,9 @@ all: manager
 test: generate fmt vet manifests
 	go test ./... -coverprofile cover.out
 
+test-e2e: generate fmt vet manifests
+	go test -v ./test/e2e -ginkgo.v
+
 # Build manager binary
 manager: generate fmt vet
 	go build -o bin/manager main.go

--- a/go.mod
+++ b/go.mod
@@ -7,12 +7,14 @@ require (
 	github.com/Masterminds/semver v1.5.0 // indirect
 	github.com/Masterminds/sprig v2.22.0+incompatible
 	github.com/go-logr/logr v0.3.0
+	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
 	github.com/huandu/xstrings v1.3.2 // indirect
 	github.com/mitchellh/copystructure v1.2.0 // indirect
 	github.com/onsi/ginkgo v1.14.1
 	github.com/onsi/gomega v1.10.2
 	github.com/pkg/errors v0.9.1
 	k8s.io/api v0.20.4
+	k8s.io/apiextensions-apiserver v0.20.4
 	k8s.io/apimachinery v0.20.4
 	k8s.io/client-go v0.20.4
 	k8s.io/kubernetes v1.21.1

--- a/go.sum
+++ b/go.sum
@@ -259,6 +259,7 @@ github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zV
 github.com/gogo/protobuf v1.3.1 h1:DqDEcV5aeaTmdFBePNpYsp3FlcVH/2ISVVM9Qf8PSls=
 github.com/gogo/protobuf v1.3.1/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=
 github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0/go.mod h1:E/TSTwGwJL78qG/PmXZO1EjYhfJinVAhrmmHX6Z8B9k=
+github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b h1:VKtxabqXZkF25pY9ekfRL6a582T4P37/31XEstQ5p58=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20160516000752-02826c3e7903/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20190129154638-5b532d6fd5ef h1:veQD95Isof8w9/WXiA+pa3tz3fJXkt5B7QaRBrM62gk=

--- a/test/e2e/client/client.go
+++ b/test/e2e/client/client.go
@@ -1,0 +1,91 @@
+package client
+
+import (
+	"os"
+
+	"github.com/golang/glog"
+	metallbv1alpha "github.com/metallb/metallb-operator/api/v1alpha1"
+	apiext "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	discovery "k8s.io/client-go/discovery"
+	"k8s.io/client-go/kubernetes/scheme"
+	appsv1client "k8s.io/client-go/kubernetes/typed/apps/v1"
+	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
+	networkv1client "k8s.io/client-go/kubernetes/typed/networking/v1"
+	rbacv1client "k8s.io/client-go/kubernetes/typed/rbac/v1"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// Client defines the client set that will be used for testing
+var Client *ClientSet
+
+func init() {
+	Client = New("")
+}
+
+// ClientSet provides the struct to talk with relevant API
+type ClientSet struct {
+	client.Client
+	corev1client.CoreV1Interface
+	networkv1client.NetworkingV1Client
+	appsv1client.AppsV1Interface
+	rbacv1client.RbacV1Interface
+	discovery.DiscoveryInterface
+	Config *rest.Config
+}
+
+// New returns a *ClientBuilder with the given kubeconfig.
+func New(kubeconfig string) *ClientSet {
+	var config *rest.Config
+	var err error
+
+	if kubeconfig == "" {
+		kubeconfig = os.Getenv("KUBECONFIG")
+	}
+
+	if kubeconfig != "" {
+		glog.V(4).Infof("Loading kube client config from path %q", kubeconfig)
+		config, err = clientcmd.BuildConfigFromFlags("", kubeconfig)
+	} else {
+		glog.V(4).Infof("Using in-cluster kube client config")
+		config, err = rest.InClusterConfig()
+	}
+	if err != nil {
+		glog.Infof("Failed to init kubernetes client, please check the $KUBECONFIG environment variable")
+		return nil
+	}
+
+	clientSet := &ClientSet{}
+	clientSet.CoreV1Interface = corev1client.NewForConfigOrDie(config)
+	clientSet.AppsV1Interface = appsv1client.NewForConfigOrDie(config)
+	clientSet.RbacV1Interface = rbacv1client.NewForConfigOrDie(config)
+	clientSet.DiscoveryInterface = discovery.NewDiscoveryClientForConfigOrDie(config)
+	clientSet.NetworkingV1Client = *networkv1client.NewForConfigOrDie(config)
+	clientSet.Config = config
+
+	myScheme := runtime.NewScheme()
+	if err = scheme.AddToScheme(myScheme); err != nil {
+		panic(err)
+	}
+
+	// Setup Scheme for all resources
+	if err := apiext.AddToScheme(myScheme); err != nil {
+		panic(err)
+	}
+
+	if err := metallbv1alpha.AddToScheme(myScheme); err != nil {
+		panic(err)
+	}
+
+	clientSet.Client, err = client.New(config, client.Options{
+		Scheme: myScheme,
+	})
+
+	if err != nil {
+		return nil
+	}
+
+	return clientSet
+}

--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -1,0 +1,181 @@
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"testing"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	metallbv1alpha "github.com/metallb/metallb-operator/api/v1alpha1"
+	testclient "github.com/metallb/metallb-operator/test/e2e/client"
+	corev1 "k8s.io/api/core/v1"
+	apiext "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/yaml"
+	goclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest/printer"
+)
+
+const (
+	// MetallbNameSpace contains the name of the MetalLB operator  namespace
+	MetallbNameSpace = "metallb-system"
+	// MetallbOperatorDeploymentName contains the name of the MetalLB operator deployment
+	MetallbOperatorDeploymentName = "metallboperator-controller-manager"
+	// MetallbOperatorDeploymentLabel contains the label of the MetalLB operator deployment
+	MetallbOperatorDeploymentLabel = "controller-manager"
+	// MetallbOperatorCRDName contains the name of the MetalLB operator CRD
+	MetallbOperatorCRDName = "metallbs.metallb.io"
+	// MetallbCRFile contains the Metallb custom resource deployment
+	MetallbCRFile = "metallb.yaml"
+	// MetallbDeploymentName contains the name of the MetalLB deployment
+	MetallbDeploymentName = "controller"
+	// MetallbDaemonsetName contains the name of the MetalLB daemonset
+	MetallbDaemonsetName = "speaker"
+)
+
+func RunE2ETests(t *testing.T) {
+	RegisterFailHandler(Fail)
+
+	RunSpecsWithDefaultAndCustomReporters(t,
+		"Controller Suite",
+		[]Reporter{printer.NewlineReporter{}})
+}
+
+var _ = Describe("validation", func() {
+	Context("MetalLB", func() {
+		It("should have the MetalLB operator deployment in running state", func() {
+			Eventually(func() bool {
+				deploy, err := testclient.Client.Deployments(MetallbNameSpace).Get(context.Background(), MetallbOperatorDeploymentName, metav1.GetOptions{})
+				if err != nil {
+					return false
+				}
+				return deploy.Status.ReadyReplicas == deploy.Status.Replicas
+			}, 5*time.Minute, 5*time.Second).Should(BeTrue())
+
+			pods, err := testclient.Client.Pods(MetallbNameSpace).List(context.Background(), metav1.ListOptions{
+				LabelSelector: fmt.Sprintf("control-plane=%s", MetallbOperatorDeploymentLabel)})
+			Expect(err).ToNot(HaveOccurred())
+
+			deploy, err := testclient.Client.Deployments(MetallbNameSpace).Get(context.Background(), MetallbOperatorDeploymentName, metav1.GetOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(len(pods.Items)).To(Equal(int(deploy.Status.Replicas)))
+
+			for _, pod := range pods.Items {
+				Expect(pod.Status.Phase).To(Equal(corev1.PodRunning))
+			}
+		})
+
+		It("should have the MetalLB CRD available in the cluster", func() {
+			crd := &apiext.CustomResourceDefinition{}
+			err := testclient.Client.Get(context.Background(), goclient.ObjectKey{Name: MetallbOperatorCRDName}, crd)
+			Expect(err).ToNot(HaveOccurred())
+		})
+	})
+
+	Context("MetalLB deploy", func() {
+		var metallb *metallbv1alpha.Metallb
+		var metallbCRExisted bool
+
+		BeforeEach(func() {
+			metallb = &metallbv1alpha.Metallb{}
+			err := loadMetallbFromFile(metallb, MetallbCRFile)
+			Expect(err).ToNot(HaveOccurred())
+
+			metallbCRExisted = true
+			err = testclient.Client.Get(context.Background(), goclient.ObjectKey{Namespace: metallb.Namespace, Name: metallb.Name}, metallb)
+			if errors.IsNotFound(err) {
+				metallbCRExisted = false
+				Expect(testclient.Client.Create(context.Background(), metallb)).Should(Succeed())
+			} else {
+				Expect(err).ToNot(HaveOccurred())
+			}
+		})
+
+		AfterEach(func() {
+			if !metallbCRExisted {
+				err := testclient.Client.Delete(context.Background(), metallb)
+				Expect(err).ToNot(HaveOccurred())
+				// Check the MetalLB custom resource is deleted to avoid status leak in between tests.
+				Eventually(func() bool {
+					err = testclient.Client.Get(context.Background(), goclient.ObjectKey{Namespace: metallb.Namespace, Name: metallb.Name}, metallb)
+					if errors.IsNotFound(err) {
+						return true
+					}
+					return false
+				}, 5*time.Minute, 5*time.Second).Should(BeTrue(), "Failed to delete MetalLB custom resource")
+			}
+		})
+
+		It("should have MetalLB pods in running state", func() {
+			By("checking MetalLB controller deployment is in running state", func() {
+				Eventually(func() bool {
+					deploy, err := testclient.Client.Deployments(metallb.Namespace).Get(context.Background(), MetallbDeploymentName, metav1.GetOptions{})
+					if err != nil {
+						return false
+					}
+					return deploy.Status.ReadyReplicas == deploy.Status.Replicas
+				}, 5*time.Minute, 5*time.Second).Should(BeTrue())
+
+				pods, err := testclient.Client.Pods(MetallbNameSpace).List(context.Background(), metav1.ListOptions{
+					LabelSelector: "component=controller"})
+				Expect(err).ToNot(HaveOccurred())
+
+				deploy, err := testclient.Client.Deployments(metallb.Namespace).Get(context.Background(), MetallbDeploymentName, metav1.GetOptions{})
+				Expect(err).ToNot(HaveOccurred())
+				Expect(len(pods.Items)).To(Equal(int(deploy.Status.Replicas)))
+
+				for _, pod := range pods.Items {
+					Expect(pod.Status.Phase).To(Equal(corev1.PodRunning))
+				}
+			})
+
+			By("checking MetalLB daemonset is in running state", func() {
+				Eventually(func() bool {
+					daemonset, err := testclient.Client.DaemonSets(metallb.Namespace).Get(context.Background(), MetallbDaemonsetName, metav1.GetOptions{})
+					if err != nil {
+						return false
+					}
+					return daemonset.Status.DesiredNumberScheduled == daemonset.Status.NumberReady
+				}, 5*time.Minute, 5*time.Second).Should(BeTrue())
+
+				pods, err := testclient.Client.Pods(MetallbNameSpace).List(context.Background(), metav1.ListOptions{
+					LabelSelector: "component=speaker"})
+				Expect(err).ToNot(HaveOccurred())
+
+				daemonset, err := testclient.Client.DaemonSets(metallb.Namespace).Get(context.Background(), MetallbDaemonsetName, metav1.GetOptions{})
+				Expect(err).ToNot(HaveOccurred())
+				Expect(len(pods.Items)).To(Equal(int(daemonset.Status.DesiredNumberScheduled)))
+
+				for _, pod := range pods.Items {
+					Expect(pod.Status.Phase).To(Equal(corev1.PodRunning))
+				}
+			})
+		})
+	})
+})
+
+func decodeYAML(r io.Reader, obj interface{}) error {
+	decoder := yaml.NewYAMLToJSONDecoder(r)
+	return decoder.Decode(obj)
+}
+
+func loadMetallbFromFile(metallb *metallbv1alpha.Metallb, fileName string) error {
+	f, err := os.Open(fmt.Sprintf("../../config/samples/%s", fileName))
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	return decodeYAML(f, metallb)
+}
+
+var _ = BeforeSuite(func() {
+	_, err := testclient.Client.Namespaces().Get(context.Background(), MetallbNameSpace, metav1.GetOptions{})
+	Expect(err).ToNot(HaveOccurred(), "Should have the MetalLB operator namespace")
+})

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -1,0 +1,9 @@
+package e2e
+
+import (
+	"testing"
+)
+
+func TestE2E(t *testing.T) {
+	RunE2ETests(t)
+}


### PR DESCRIPTION
The tests are validating that all the nodes in the cluster and
the operator pods are running after operator deployment.