### PR TITLE
Add build flag to e2e tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ test: generate fmt vet manifests
 	go test ./... -coverprofile cover.out
 
 test-e2e: generate fmt vet manifests
-	go test -v ./test/e2e -ginkgo.v
+	go test --tags=e2etests -v ./test/e2e -ginkgo.v
 
 # Build manager binary
 manager: generate fmt vet

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -1,3 +1,5 @@
+// +build e2etests
+
 package e2e
 
 import (


### PR DESCRIPTION
E2e tests need a live cluster, and we don't want to run them when running unit tests via make test. Here a build flag makes make test skip e2e tests