### PR TITLE
Add make help command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,8 +39,6 @@ OPERATOR_SDK_URL=https://api.github.com/repos/operator-framework/operator-sdk/re
 OLM_URL=https://api.github.com/repos/operator-framework/operator-lifecycle-manager/releases
 OPM_TOOL_URL=https://api.github.com/repos/operator-framework/operator-registry/releases
 
-all: manager
-
 # Run tests
 ENVTEST_ASSETS_DIR=$(shell pwd)/testbin
 test: generate fmt vet manifests
@@ -48,64 +46,58 @@ test: generate fmt vet manifests
 	test -f ${ENVTEST_ASSETS_DIR}/setup-envtest.sh || curl -sSLo ${ENVTEST_ASSETS_DIR}/setup-envtest.sh https://raw.githubusercontent.com/kubernetes-sigs/controller-runtime/v0.8.3/hack/setup-envtest.sh
 	source ${ENVTEST_ASSETS_DIR}/setup-envtest.sh; fetch_envtest_tools $(ENVTEST_ASSETS_DIR); setup_envtest_env $(ENVTEST_ASSETS_DIR); go test ./... -coverprofile cover.out
 
-test-e2e: generate fmt vet manifests
+all: manager ## Default make target if no options specified
+
+test: generate fmt vet manifests  ## Run tests
+	go test ./... -coverprofile cover.out
+
+test-e2e: generate fmt vet manifests  ## Run e2e tests
 	go test --tags=e2etests -v ./test/e2e -ginkgo.v
 
-# Build manager binary
-manager: generate fmt vet
+manager: generate fmt vet  ## Build manager binary
 	go build -o bin/manager main.go
 
-# Run against the configured Kubernetes cluster in ~/.kube/config
-run: generate fmt vet manifests
+run: generate fmt vet manifests  ## Run against the configured cluster
 	go run ./main.go
 
-# Install CRDs into a cluster
-install: manifests kustomize
+install: manifests kustomize  ## Install CRDs into a cluster
 	$(KUSTOMIZE) build config/crd | kubectl apply -f -
 
-# Uninstall CRDs from a cluster
-uninstall: manifests kustomize
+uninstall: manifests kustomize  ## Uninstall CRDs from a cluster
 	$(KUSTOMIZE) build config/crd | kubectl delete -f -
 
-# Deploy controller in the configured Kubernetes cluster in ~/.kube/config
-deploy: manifests kustomize
+deploy: manifests kustomize  ## Deploy controller in the configured cluster
 	cd config/manager && kustomize edit set image controller=${IMG}
 	$(KUSTOMIZE) build $(KUSTOMIZE_DEPLOY_DIR) | kubectl apply -f -
 	$(KUSTOMIZE) build config/metallb_rbac | kubectl apply -f -
 
-# Generate manifests e.g. CRD, RBAC etc.
-manifests: controller-gen
+manifests: controller-gen  ## Generate manifests e.g. CRD, RBAC etc.
 	$(CONTROLLER_GEN) $(CRD_OPTIONS) rbac:roleName=manager-role webhook paths="./..." output:crd:artifacts:config=config/crd/bases
 
-# Run go fmt against code
-fmt:
+fmt:  ## Run go fmt against code
+	[ -z "`gofmt -s -w -l -e .`" ]
 	go fmt ./...
 
-# Run go vet against code
-vet:
+vet:  ## Run go vet against code
 	go vet ./...
 
-# Generate code
-generate: controller-gen
+generate: controller-gen  ## Generate code
 	$(CONTROLLER_GEN) object:headerFile="hack/boilerplate.go.txt" paths="./..."
 
 # Build the docker image
-docker-build:
+docker-build:  ## Build the docker image
 	docker build . -t ${IMG}
 
-# Push the docker image
-docker-push:
+docker-push:  ## Push the docker image
 	docker push ${IMG}
 
-# Generate bundle manifests and metadata, then validate generated files.
-bundle: operator-sdk manifests
+bundle: operator-sdk manifests ## Generate bundle manifests and metadata, then validate generated files.
 	$(OPERATOR_SDK) generate kustomize manifests --interactive=false -q
 	cd config/manager && $(KUSTOMIZE) edit set image controller=$(IMG)
 	$(KUSTOMIZE) build config/manifests | $(OPERATOR_SDK) generate bundle -q --overwrite --version $(VERSION) $(BUNDLE_METADATA_OPTS) --extra-service-accounts "controller,speaker"
 	$(OPERATOR_SDK) bundle validate ./bundle
 
-# Build the bundle image.
-build-bundle:
+build-bundle: ## Build the bundle image.
 	docker build -f bundle.Dockerfile -t $(BUNDLE_IMG) .
 
 deploy-olm:
@@ -118,12 +110,10 @@ deploy-with-olm:
 	sed -i 's#mymetallb#$(NAMESPACE)#g' config/olm-install/install-resources.yaml
 	$(KUSTOMIZE) build config/olm-install | kubectl apply -f -
 
-# Build the bundle index image.
-bundle-index-build: opm
+bundle-index-build: opm  ## Build the bundle index image.
 	$(OPM) index add --bundles $(BUNDLE_IMG) --tag $(BUNDLE_INDEX_IMG) -c docker
 
-# Generate and push bundle image and bundle index image
-build-and-push-bundle-images: docker-build docker-push
+build-and-push-bundle-images: docker-build docker-push  ## Generate and push bundle image and bundle index image
 	$(MAKE) bundle
 	$(MAKE) build-bundle
 	$(MAKE) docker-push IMG=$(BUNDLE_IMG)
@@ -192,10 +182,14 @@ else
 OPM=$(shell which opm)
 endif
 
-generate-metallb-manifests:
+generate-metallb-manifests:  ## Generate metallb manifests
 	@echo "Generating MetalLB manifests"
 	hack/generate-metallb-manifests.sh
 
-validate-metallb-manifests:
+validate-metallb-manifests:  ## Validate metallb manifests
 	@echo "Comparing newly generated MetalLB manifests to existing ones"
 	hack/compare-gen-manifests.sh
+
+help:  ## Show this help
+	@grep -F -h "##" $(MAKEFILE_LIST) | grep -F -v grep | sed -e 's/\\$$//' \
+		| awk -F'[:#]' '{print $$1 = sprintf("%-30s", $$1), $$4}'


### PR DESCRIPTION
Signed-off-by: Mohamed Mahmoud <mmahmoud@redhat.com>
```
make help
test                            Run tests
test-e2e                        Run e2e tests
manager                         Build manager binary
run                             Run against the configured cluster
install                         Install CRDs into a cluster
uninstall                       Uninstall CRDs from a cluster
deploy                          Deploy controller in the configured cluster
manifests                       Generate manifests e.g. CRD, RBAC etc.
fmt                             Run go fmt against code
vet                             Run go vet against code
generate                        Generate code
docker-build                    Build the docker image
docker-push                     Push the docker image
controller-gen                  Find or download controller-gen
generate-metallb-manifests      Generate metallb manifests
validate-metallb-manifests      Validate metallb manifests
help                            Show this help
```

If you are adding new make target just add a comment starts with `##` beside the new target and describe what this command do, then confirm you can see the output with `make help`