### PR TITLE
Fix ConfigMap merge function and adding unit-test

### DIFF
--- a/api/v1alpha1/addresspool_types.go
+++ b/api/v1alpha1/addresspool_types.go
@@ -39,7 +39,7 @@ type AddressPoolSpec struct {
 	// for a pool.
 	// +optional
 	// +kubebuilder:default:=true
-	AutoAssign *bool `json:"autoAssign,omitempty"`
+	AutoAssign *bool `json:"autoAssign,omitempty" yaml:"autoAssign,omitempty"`
 }
 
 // AddressPoolStatus defines the observed state of AddressPool

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/onsi/ginkgo v1.14.1
 	github.com/onsi/gomega v1.10.2
 	github.com/pkg/errors v0.9.1
+	gopkg.in/yaml.v2 v2.3.0 // indirect
 	k8s.io/api v0.20.4
 	k8s.io/apiextensions-apiserver v0.20.4
 	k8s.io/apimachinery v0.20.4

--- a/pkg/apply/merge_test.go
+++ b/pkg/apply/merge_test.go
@@ -302,7 +302,7 @@ func UnstructuredFromYaml(t *testing.T, obj string) *uns.Unstructured {
 	return &u
 }
 
-func TestMergeConfigMapSingelObject(t *testing.T) {
+func TestMergeConfigMapSingleObject(t *testing.T) {
 	g := NewGomegaWithT(t)
 
 	cur := UnstructuredFromYaml(t, `
@@ -329,7 +329,7 @@ metadata:
 data:
   config: |
     address-pools:
-    - name: sliver
+    - name: silver
       protocol: layer2
       addresses:
       - 172.22.0.100/24
@@ -345,7 +345,7 @@ data:
   addresses:
   - 172.20.0.100/24
   autoAssign: false
-- name: sliver
+- name: silver
   protocol: layer2
   addresses:
   - 172.22.0.100/24


### PR DESCRIPTION
Signed-off-by: Mohamed Mahmoud <mmahmoud@redhat.com>
- added test cases for configmap merge function
```
=== RUN   TestMergeConfigMapSingelObject
--- PASS: TestMergeConfigMapSingelObject (0.00s)
=== RUN   TestMergeConfigMapMultipleObjects
--- PASS: TestMergeConfigMapMultipleObjects (0.00s)
```
- merged configmap has multiple address-pools field incorrectly it should have only one
- Note duplicated address-pools today is alreadh handled by metallb controller and it will fail the config hence IMO we don't need to duplicate the same check here