### PR TITLE
Fix AddressPool resources add/delete handling

### DIFF
--- a/api/v1alpha1/addresspool_types.go
+++ b/api/v1alpha1/addresspool_types.go
@@ -39,7 +39,7 @@ type AddressPoolSpec struct {
 	// for a pool.
 	// +optional
 	// +kubebuilder:default:=true
-	AutoAssign *bool `json:"autoAssign,omitempty" yaml:"autoAssign,omitempty"`
+	AutoAssign *bool `json:"auto-assign,omitempty" yaml:"auto-assign,omitempty"`
 }
 
 // AddressPoolStatus defines the observed state of AddressPool

--- a/config/crd/bases/metallb.io_addresspools.yaml
+++ b/config/crd/bases/metallb.io_addresspools.yaml
@@ -44,7 +44,7 @@ spec:
                 items:
                   type: string
                 type: array
-              autoAssign:
+              auto-assign:
                 default: true
                 description: AutoAssign flag used to prevent MetallB from automatic
                   allocation for a pool.

--- a/config/samples/metallb.io_v1alpha1_addresspool.yaml
+++ b/config/samples/metallb.io_v1alpha1_addresspool.yaml
@@ -19,7 +19,7 @@ spec:
   protocol: layer2
   addresses:
     - 172.20.0.100/24
-  autoAssign: false
+  auto-assign: false
 ---
 apiVersion: metallb.io/v1alpha1
 kind: AddressPool

--- a/controllers/addresspool_controller.go
+++ b/controllers/addresspool_controller.go
@@ -18,12 +18,14 @@ package controllers
 
 import (
 	"context"
+	"fmt"
 	"github.com/go-logr/logr"
-	"github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"time"
 
 	metallbv1alpha1 "github.com/metallb/metallb-operator/api/v1alpha1"
@@ -47,20 +49,27 @@ const (
 // +kubebuilder:rbac:groups=metallb.io,resources=addresspools/status,verbs=get;update;patch
 
 func (r *AddressPoolReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	log := r.Log.WithValues("addresspool", req.NamespacedName)
-	log.Info("Reconciling AddressPool resource")
+	_ = r.Log.WithValues("addresspool", req.NamespacedName)
+	r.Log.Info(fmt.Sprintf("Starting AddressPool reconcile loop for %v", req.NamespacedName))
 
 	instance := &metallbv1alpha1.AddressPool{}
+	defer r.Log.Info(fmt.Sprintf("Finish AddressPool reconcile loop for %v", req.NamespacedName))
+
 	if err := r.Get(ctx, req.NamespacedName, instance); err != nil {
+		if errors.IsNotFound(err) {
+			err = r.resyncMetallbAddressPool(req)
+			if err != nil {
+				return ctrl.Result{}, err
+			}
+		}
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 	err := r.syncMetalLBAddressPool(instance)
 	if err != nil {
-		errors.Wrap(err, "Failed to create address-pool config map")
+		r.Log.Info(fmt.Sprintf("sync MetalLB addresspool failed %s", err))
 		return ctrl.Result{RequeueAfter: RetryPeriod}, err
 	}
 
-	log.Info("Reconcile complete")
 	return ctrl.Result{}, nil
 }
 
@@ -72,21 +81,50 @@ func (r *AddressPoolReconciler) syncMetalLBAddressPool(instance *metallbv1alpha1
 	data.Data["Addresses"] = instance.Spec.Addresses
 	objs, err := render.RenderDir(AddressPoolManifestPath, &data)
 	if err != nil {
-		return errors.Wrapf(err, "Fail to render address-pool manifest")
+		return fmt.Errorf("Fail to render address-pool manifest %v", err)
 	}
 
 	for _, obj := range objs {
-		if err := controllerutil.SetControllerReference(instance, obj, r.Scheme); err != nil {
-			return errors.Wrapf(err, "Failed to set controller reference to %s %s",
-				obj.GetNamespace(), obj.GetName())
-		}
 		if err := apply.ApplyObject(context.Background(), r.Client, obj); err != nil {
-			err = errors.Wrapf(err, "could not apply (%s) %s/%s", obj.GroupVersionKind(),
-				obj.GetNamespace(), obj.GetName())
+			err = fmt.Errorf("could not apply (%s) %s/%s err %v", obj.GroupVersionKind(),
+				obj.GetNamespace(), obj.GetName(), err)
 		}
 	}
 
 	return err
+}
+
+func (r *AddressPoolReconciler) resyncMetallbAddressPool(req ctrl.Request) error {
+	instanceList := &metallbv1alpha1.AddressPoolList{}
+	configMap := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "config",
+			Namespace: req.Namespace,
+		},
+	}
+
+	// Delete the exiting configMap
+	if err := r.Delete(context.Background(), configMap); err != nil {
+		// if we don't have ConfigMap then there is nothing to do
+		if errors.IsNotFound(err) {
+			return nil
+		}
+		r.Log.Info(fmt.Sprintf("Failed to delete existing Configmap %s", err))
+		return err
+	}
+
+	if err := r.List(context.Background(), instanceList); err != nil {
+		r.Log.Info(fmt.Sprintf("Failed to get existing addresspool objects %s", err))
+		return err
+	}
+
+	for _, instance := range instanceList.Items {
+		if err := r.syncMetalLBAddressPool(&instance); err != nil {
+			r.Log.Info(fmt.Sprintf("Failed to sync AddressPool intance %v err %s", instance, err))
+			return err
+		}
+	}
+	return nil
 }
 
 func (r *AddressPoolReconciler) SetupWithManager(mgr ctrl.Manager) error {

--- a/pkg/apply/apply.go
+++ b/pkg/apply/apply.go
@@ -14,13 +14,12 @@ import (
 	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// ApplyObject applies the desired object against the apiserver,
-// merging it with any existing objects if already present.
-func ApplyObject(ctx context.Context, client k8sclient.Client, obj *uns.Unstructured) error {
+// Find existing object or create if if it doesn't exists
+func findOrCreateObject(ctx context.Context, client k8sclient.Client, obj *uns.Unstructured) (*uns.Unstructured, string, error) {
 	name := obj.GetName()
 	namespace := obj.GetNamespace()
 	if name == "" {
-		return errors.Errorf("Object %s has no name", obj.GroupVersionKind().String())
+		return nil, "", errors.Errorf("Object %s has no name", obj.GroupVersionKind().String())
 	}
 	gvk := obj.GroupVersionKind()
 	// used for logging and errors
@@ -28,7 +27,7 @@ func ApplyObject(ctx context.Context, client k8sclient.Client, obj *uns.Unstruct
 	log.Printf("reconciling %s", objDesc)
 
 	if err := IsObjectSupported(obj); err != nil {
-		return errors.Wrapf(err, "object %s unsupported", objDesc)
+		return nil, objDesc, errors.Wrapf(err, "object %s unsupported", objDesc)
 	}
 
 	// Get existing
@@ -40,11 +39,25 @@ func ApplyObject(ctx context.Context, client k8sclient.Client, obj *uns.Unstruct
 		log.Printf("does not exist, creating %s", objDesc)
 		err := client.Create(ctx, obj)
 		if err != nil {
-			return errors.Wrapf(err, "could not create %s", objDesc)
+			return nil, objDesc, errors.Wrapf(err, "could not create %s", objDesc)
 		}
 		log.Printf("successfully created %s", objDesc)
+		return obj, objDesc, nil
+	}
+
+	return existing, objDesc, err
+}
+
+// ApplyObject applies the desired object against the apiserver,
+// merging it with any existing objects if already present.
+func ApplyObject(ctx context.Context, client k8sclient.Client, obj *uns.Unstructured) error {
+
+	existing, objDesc, err := findOrCreateObject(ctx, client, obj)
+
+	if existing == nil {
 		return nil
 	}
+
 	if err != nil {
 		return errors.Wrapf(err, "could not retrieve existing %s", objDesc)
 	}
@@ -55,6 +68,42 @@ func ApplyObject(ctx context.Context, client k8sclient.Client, obj *uns.Unstruct
 	}
 	if !equality.Semantic.DeepEqual(existing, obj) {
 		if err := client.Update(ctx, obj); err != nil {
+			return errors.Wrapf(err, "could not update object %s", objDesc)
+		} else {
+			log.Printf("update was successful")
+		}
+	}
+
+	return nil
+}
+
+// ApplyObjects it applies a list of desired objects after merging them.
+func ApplyObjects(ctx context.Context, client k8sclient.Client, objs []*uns.Unstructured) error {
+
+	var lastObj, existing *uns.Unstructured = nil, nil
+	var objDesc string = ""
+	var err error = nil
+
+	existing, objDesc, err = findOrCreateObject(ctx, client, objs[0])
+	if existing == nil {
+		return nil
+	}
+	if err != nil {
+		return errors.Wrapf(err, "could not retrieve existing %s", objDesc)
+	}
+
+	for _, obj := range objs {
+		if lastObj != nil {
+			// Merge the desired object with what actually exists
+			if err := MergeObjectForUpdate(existing, obj); err != nil {
+				return errors.Wrapf(err, "could not merge object %s with existing", objDesc)
+			}
+		}
+		lastObj = obj
+	}
+
+	if !equality.Semantic.DeepEqual(existing, lastObj) && lastObj != nil {
+		if err := client.Update(ctx, lastObj); err != nil {
 			return errors.Wrapf(err, "could not update object %s", objDesc)
 		} else {
 			log.Printf("update was successful")

--- a/pkg/apply/merge_test.go
+++ b/pkg/apply/merge_test.go
@@ -318,7 +318,7 @@ data:
       protocol: layer2
       addresses:
       - 172.20.0.100/24
-      autoAssign: false`)
+      auto-assign: false`)
 
 	upd := UnstructuredFromYaml(t, `
 apiVersion: v1
@@ -333,7 +333,7 @@ data:
       protocol: layer2
       addresses:
       - 172.22.0.100/24
-      autoAssign: false`)
+      auto-assign: false`)
 
 	err := MergeObjectForUpdate(cur, upd)
 	g.Expect(err).NotTo(HaveOccurred())
@@ -344,12 +344,12 @@ data:
   protocol: layer2
   addresses:
   - 172.20.0.100/24
-  autoAssign: false
+  auto-assign: false
 - name: silver
   protocol: layer2
   addresses:
   - 172.22.0.100/24
-  autoAssign: false
+  auto-assign: false
 `))
 }
 
@@ -373,7 +373,7 @@ data:
       protocol: layer2
       addresses:
       - 172.20.0.100/24
-      autoAssign: false`)
+      auto-assign: false`)
 
 	upd := UnstructuredFromYaml(t, `
 apiVersion: v1
@@ -392,7 +392,7 @@ data:
       protocol: layer2
       addresses:
       - 172.20.0.100/24
-      autoAssign: false`)
+      auto-assign: false`)
 
 	err := MergeObjectForUpdate(cur, upd)
 	g.Expect(err).NotTo(HaveOccurred())
@@ -407,7 +407,7 @@ data:
   protocol: layer2
   addresses:
   - 172.20.0.100/24
-  autoAssign: false
+  auto-assign: false
 - name: yellow
   protocol: layer2
   addresses:
@@ -416,6 +416,6 @@ data:
   protocol: layer2
   addresses:
   - 172.20.0.100/24
-  autoAssign: false
+  auto-assign: false
 `))
 }

--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -336,6 +336,200 @@ var _ = Describe("validation", func() {
 			})
 		})
 	})
+	Context("Testing create/delete Multiple AddressPools", func() {
+		By("Creating first addresspool object ", func() {
+			addresspool := &metallbv1alpha1.AddressPool{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "addresspool1",
+					Namespace: consts.MetallbNameSpace,
+				},
+				Spec: metallbv1alpha1.AddressPoolSpec{
+					Name:     "test1",
+					Protocol: "layer2",
+					Addresses: []string{
+						"1.1.1.1",
+						"1.1.1.100",
+					},
+				},
+			}
+
+			Expect(testclient.Client.Create(context.Background(), addresspool)).Should(Succeed())
+
+			key := types.NamespacedName{
+				Name:      "addresspool1",
+				Namespace: consts.MetallbNameSpace,
+			}
+			// Create addresspool resource
+			By("By checking AddressPool1 resource is created")
+			Eventually(func() error {
+				err := testclient.Client.Get(context.Background(), key, addresspool)
+				return err
+			}, timeout, interval).Should(Succeed())
+
+			// Checking ConfigMap is created
+			By("By checking ConfigMap is created and matches addresspool1 configuration")
+			Eventually(func() (string, error) {
+				configmap, err := testclient.Client.ConfigMaps(consts.MetallbNameSpace).Get(context.Background(), consts.MetallbConfigMapName, metav1.GetOptions{})
+				if err != nil {
+					return "", err
+				}
+				return configmap.Data[consts.MetallbConfigMapName], err
+			}, timeout, interval).Should(MatchYAML(`address-pools:
+- name: test1
+  protocol: layer2
+  addresses:
+
+  - 1.1.1.1
+  - 1.1.1.100
+
+`))
+
+		})
+
+		By("Creating second addresspool object ", func() {
+			addresspool := &metallbv1alpha1.AddressPool{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "addresspool2",
+					Namespace: consts.MetallbNameSpace,
+				},
+				Spec: metallbv1alpha1.AddressPoolSpec{
+					Name:     "test2",
+					Protocol: "layer2",
+					Addresses: []string{
+						"2.2.2.1",
+						"2.2.2.100",
+					},
+					AutoAssign: &autoAssign,
+				},
+			}
+
+			Expect(testclient.Client.Create(context.Background(), addresspool)).Should(Succeed())
+
+			key := types.NamespacedName{
+				Name:      "addresspool2",
+				Namespace: consts.MetallbNameSpace,
+			}
+			// Create addresspool resource
+			By("By checking AddressPool2 resource is created")
+			Eventually(func() error {
+				err := testclient.Client.Get(context.Background(), key, addresspool)
+				return err
+			}, timeout, interval).Should(Succeed())
+
+			// Checking ConfigMap is created
+			By("By checking ConfigMap is created and matches addresspool2 configuration")
+			Eventually(func() (string, error) {
+				configmap, err := testclient.Client.ConfigMaps(consts.MetallbNameSpace).Get(context.Background(), consts.MetallbConfigMapName, metav1.GetOptions{})
+				if err != nil {
+					return "", err
+				}
+				return configmap.Data[consts.MetallbConfigMapName], err
+			}, timeout, interval).Should(MatchYAML(`address-pools:
+- name: test1
+  protocol: layer2
+  addresses:
+
+  - 1.1.1.1
+  - 1.1.1.100
+
+- name: test2
+  protocol: layer2
+  auto-assign: false
+  addresses:
+
+  - 2.2.2.1
+  - 2.2.2.100
+
+`))
+		})
+
+		By("Deleteing the first addresspool object", func() {
+			addresspool := &metallbv1alpha1.AddressPool{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "addresspool1",
+					Namespace: consts.MetallbNameSpace,
+				},
+				Spec: metallbv1alpha1.AddressPoolSpec{
+					Name:     "test1",
+					Protocol: "layer2",
+					Addresses: []string{
+						"1.1.1.1",
+						"1.1.1.100",
+					},
+				},
+			}
+			Eventually(func() bool {
+				err := testclient.Client.Delete(context.Background(), addresspool)
+				return errors.IsNotFound(err)
+			}, timeout, interval).Should(BeTrue(), "Failed to delete AddressPool custom resource")
+
+			By("By checking ConfigMap matches the expected configuration")
+			Eventually(func() (string, error) {
+				configmap, err := testclient.Client.ConfigMaps(consts.MetallbNameSpace).Get(context.Background(), consts.MetallbConfigMapName, metav1.GetOptions{})
+				if err != nil {
+					// if its notfound means that was the last addresspool and configmap is deleted
+					if errors.IsNotFound(err) {
+						return "", nil
+					}
+					return "", err
+				}
+				return configmap.Data[consts.MetallbConfigMapName], err
+			}, timeout, interval).Should(MatchYAML(`address-pools:
+- name: test2
+  protocol: layer2
+  auto-assign: false
+  addresses:
+
+  - 2.2.2.1
+  - 2.2.2.100
+
+`))
+
+		})
+
+		By("Deleteing the second addresspool object", func() {
+			addresspool := &metallbv1alpha1.AddressPool{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "addresspool2",
+					Namespace: consts.MetallbNameSpace,
+				},
+				Spec: metallbv1alpha1.AddressPoolSpec{
+					Name:     "test2",
+					Protocol: "layer2",
+					Addresses: []string{
+						"2.2.2.1",
+						"2.2.2.100",
+					},
+				},
+			}
+			Eventually(func() bool {
+				err := testclient.Client.Delete(context.Background(), addresspool)
+				return errors.IsNotFound(err)
+			}, timeout, interval).Should(BeTrue(), "Failed to delete AddressPool custom resource")
+
+			By("By checking ConfigMap matches the expected configuration")
+			Eventually(func() (string, error) {
+				configmap, err := testclient.Client.ConfigMaps(consts.MetallbNameSpace).Get(context.Background(), consts.MetallbConfigMapName, metav1.GetOptions{})
+				if err != nil {
+					// if its notfound means that was the last addresspool and configmap is deleted
+					if errors.IsNotFound(err) {
+						return "", nil
+					}
+					return "", err
+				}
+				return configmap.Data[consts.MetallbConfigMapName], err
+			}, timeout, interval).Should(MatchYAML(`
+`))
+
+		})
+
+		// Make sure Configmap is deleted at the end of this test
+		By("By checking ConfigMap is deleted at the end of the test")
+		Eventually(func() bool {
+			_, err := testclient.Client.ConfigMaps(consts.MetallbNameSpace).Get(context.Background(), consts.MetallbConfigMapName, metav1.GetOptions{})
+			return errors.IsNotFound(err)
+		}, timeout, interval).Should(BeTrue())
+	})
 })
 
 func decodeYAML(r io.Reader, obj interface{}) error {


### PR DESCRIPTION
fix #32 
also the autoassign fields has to match the string in the configmap so we can merge yamls etc and generate correct configmap, so standalone testing as well as e2e and deployment all work with the same structure type