### PR TITLE
Add required RBAC permissions for deployment on OCP

### DIFF
--- a/bundle/manifests/metallb-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/metallb-operator.clusterserviceversion.yaml
@@ -160,6 +160,15 @@ spec:
         - apiGroups:
           - metallb.io
           resources:
+          - metallbs/finalizers
+          verbs:
+          - delete
+          - get
+          - patch
+          - update
+        - apiGroups:
+          - metallb.io
+          resources:
           - metallbs/status
           verbs:
           - get

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -41,6 +41,15 @@ rules:
 - apiGroups:
   - metallb.io
   resources:
+  - metallbs/finalizers
+  verbs:
+  - delete
+  - get
+  - patch
+  - update
+- apiGroups:
+  - metallb.io
+  resources:
   - metallbs/status
   verbs:
   - get

--- a/controllers/metallb_controller.go
+++ b/controllers/metallb_controller.go
@@ -55,6 +55,7 @@ var ManifestPath = "./bindata/deployment"
 // +kubebuilder:rbac:groups=metallb.io,resources=metallbs,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=metallb.io,resources=metallbs/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=policy,resources=podsecuritypolicies,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=metallb.io,resources=metallbs/finalizers,verbs=delete;get;update;patch
 
 func (r *MetallbReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	_ = context.Background()


### PR DESCRIPTION
metallb-operator is missing the required RBAC permissions to work on OCP according to [Operator SDK Documentation](https://sdk.operatorframework.io/docs/faqs/#after-deploying-my-operator-why-do-i-see-errors-like-is-forbidden-cannot-set-blockownerdeletion-if-an-ownerreference-refers-to-a-resource-you-cant-set-finalizers-on-)

This change will fix the following error:

`
2021-07-08T15:27:17.493Z	ERROR	controller-runtime.manager.controller.metallb	Reconciler error	{"reconciler group": "metallb.io", "reconciler kind": "Metallb", "name": "metallb", "namespace": "metallb-system", "error": "FailedToSyncMetalLBResources: could not apply (policy/v1beta1, Kind=PodSecurityPolicy) metallb-system/controller: could not update object (policy/v1beta1, Kind=PodSecurityPolicy) metallb-system/controller: podsecuritypolicies.policy \"controller\" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>", "errorVerbose": "podsecuritypolicies.policy \"controller\" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>\ncould not update object (policy/v1beta1, Kind=PodSecurityPolicy) metallb-system/controller\ngithub.com/metallb/metallb-operator/pkg/apply.ApplyObject\n\t/workspace/pkg/apply/apply.go:71`