### PR TITLE
Add speaker DaemonSet elevated privileges

### DIFF
--- a/bundle/manifests/metallb-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/metallb-operator.clusterserviceversion.yaml
@@ -341,6 +341,14 @@ spec:
           - pods
           verbs:
           - list
+        - apiGroups:
+          - security.openshift.io
+          resourceNames:
+          - privileged
+          resources:
+          - securitycontextconstraints
+          verbs:
+          - use
         serviceAccountName: speaker
     strategy: deployment
   installModes:

--- a/config/metallb_rbac/kustomization.yaml
+++ b/config/metallb_rbac/kustomization.yaml
@@ -1,2 +1,3 @@
 resources:
 - metallb.yaml
+- speaker_role_binding.yaml

--- a/config/metallb_rbac/speaker_role_binding.yaml
+++ b/config/metallb_rbac/speaker_role_binding.yaml
@@ -1,0 +1,28 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: speaker
+  namespace: metallb-system
+rules:
+  - apiGroups:
+      - security.openshift.io
+    resourceNames:
+      - privileged
+    resources:
+      - securitycontextconstraints
+    verbs:
+      - use
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: speaker
+  namespace: metallb-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: speaker
+subjects:
+  - kind: ServiceAccount
+    name: speaker
+    namespace: metallb-system


### PR DESCRIPTION
MetalLB speaker DaemonSet requires elevated privileges according to [metallb-on-openshift documentation](https://metallb.universe.tf/installation/clouds/#metallb-on-openshift-ocp), so it can do the raw networking required to make LoadBalancers work.

This change will fix the following error:

`  Warning  FailedCreate  66s (x12 over 76s)  daemonset-controller  Error creating: pods "speaker-" is forbidden: unable to validate against any security context constraint: [provider "anyuid": Forbidden: not usable by user or serviceaccount, provider restricted: .spec.securityContext.hostNetwork: Invalid value: true: Host network is not allowed to be used, spec.containers[0].securityContext.capabilities.add: Invalid value: "NET_RAW": capability may not be added, spec.containers[0].securityContext.hostNetwork: Invalid value: true: Host network is not allowed to be used, spec.containers[0].securityContext.containers[0].hostPort: Invalid value: 7472: Host ports are not allowed to be used, spec.containers[0].securityContext.containers[0].hostPort: Invalid value: 7946: Host ports are not allowed to be used, provider "nonroot": Forbidden: not usable by user or serviceaccount, provider "hostmount-anyuid": Forbidden: not usable by user or serviceaccount, provider "machine-api-termination-handler": Forbidden: not usable by user or serviceaccount, provider "hostnetwork": Forbidden: not usable by user or serviceaccount, provider "hostaccess": Forbidden: not usable by user or serviceaccount, provider "node-exporter": Forbidden: not usable by user or serviceaccount, provider "privileged": Forbidden: not usable by user or serviceaccount]`