### PR TITLE
Add latest git commit to SetupLog

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,9 +16,11 @@ COPY controllers/ controllers/
 COPY pkg/ pkg/
 COPY bindata/deployment/ bindata/deployment/
 COPY bindata/configuration/address-pool/ bindata/configuration/address-pool/
+COPY .git/ .git/
+COPY Makefile Makefile
 
 # Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o manager main.go
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -ldflags "-X main.build=$(git rev-parse HEAD)" -o manager main.go 
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details

--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ test-e2e: generate fmt vet manifests  ## Run e2e tests
 	go test --tags=e2etests -v ./test/e2e -ginkgo.v
 
 manager: generate fmt vet  ## Build manager binary
-	go build -o bin/manager main.go
+	go build -ldflags "-X main.build=$$(git rev-parse HEAD)" -o bin/manager main.go
 
 run: generate fmt vet manifests  ## Run against the configured cluster
 	go run ./main.go

--- a/main.go
+++ b/main.go
@@ -54,6 +54,9 @@ func init() {
 	// +kubebuilder:scaffold:scheme
 }
 
+// build is the git version of this program. It is set using build flags in the makefile.
+var build = "develop"
+
 func main() {
 	var metricsAddr string
 	var enableLeaderElection bool
@@ -64,6 +67,8 @@ func main() {
 	flag.Parse()
 
 	ctrl.SetLogger(zap.New(zap.UseDevMode(true)))
+
+	setupLog.Info("git commit:", "id", build)
 
 	watchNamepace := checkEnvVar("WATCH_NAMESPACE")
 	checkEnvVar("SPEAKER_IMAGE")


### PR DESCRIPTION
Adding this so the first line of the operator's output will include
the latest git commit it was built in.
Will look something like this: "INFO	setup	git commit:	{"id": "ebc09d2f082bb147812d9064fa754db8f969ddcc"}"

Signed-off-by: Ori Braunshtein <obraunsh@redhat.com>