### PR TITLE
Add verification of bundle manifests

### DIFF
--- a/.github/workflows/olm.yml
+++ b/.github/workflows/olm.yml
@@ -38,9 +38,9 @@ jobs:
         make fmt
         git diff --exit-code
   
-    - name: Verify manifests
+    - name: Verify bundle manifests
       run: |
-        make manifests
+        make bundle
         git diff --exit-code
 
     - name: Create and set up K8s Kind Cluster


### PR DESCRIPTION
Adding this to the ci so it fails if there are necessary changes to the bundle
manifests that weren't included in the PR

Signed-off-by: Ori Braunshtein <obraunsh@redhat.com>