### PR TITLE
Rename to autoAssign in CRD

### DIFF
--- a/api/v1alpha1/addresspool_types.go
+++ b/api/v1alpha1/addresspool_types.go
@@ -39,7 +39,7 @@ type AddressPoolSpec struct {
 	// for a pool.
 	// +optional
 	// +kubebuilder:default:=true
-	AutoAssign *bool `json:"auto-assign,omitempty" yaml:"auto-assign,omitempty"`
+	AutoAssign *bool `json:"autoAssign,omitempty" yaml:"auto-assign,omitempty"`
 }
 
 // AddressPoolStatus defines the observed state of AddressPool

--- a/bindata/configuration/address-pool/addresspool_config.yaml
+++ b/bindata/configuration/address-pool/addresspool_config.yaml
@@ -14,6 +14,6 @@ data:
       - {{ $address }}
       {{ end -}}
 
-      {{ $auto_assign := .AutoAssign }} {{ if ne $auto_assign true }}
+      {{ $auto_assign := .AutoAssign }} {{ if not $auto_assign }}
       auto-assign: {{ $auto_assign }}
       {{ end }}

--- a/bundle/manifests/metallb-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/metallb-operator.clusterserviceversion.yaml
@@ -30,7 +30,7 @@ metadata:
             "addresses": [
               "172.20.0.100/24"
             ],
-            "auto-assign": false,
+            "autoAssign": false,
             "name": "gold",
             "protocol": "layer2"
           }

--- a/bundle/manifests/metallb.io_addresspools.yaml
+++ b/bundle/manifests/metallb.io_addresspools.yaml
@@ -42,7 +42,7 @@ spec:
                 items:
                   type: string
                 type: array
-              auto-assign:
+              autoAssign:
                 default: true
                 description: AutoAssign flag used to prevent MetallB from automatic
                   allocation for a pool.

--- a/config/crd/bases/metallb.io_addresspools.yaml
+++ b/config/crd/bases/metallb.io_addresspools.yaml
@@ -44,7 +44,7 @@ spec:
                 items:
                   type: string
                 type: array
-              auto-assign:
+              autoAssign:
                 default: true
                 description: AutoAssign flag used to prevent MetallB from automatic
                   allocation for a pool.

--- a/config/samples/metallb.io_v1alpha1_addresspool.yaml
+++ b/config/samples/metallb.io_v1alpha1_addresspool.yaml
@@ -19,7 +19,7 @@ spec:
   protocol: layer2
   addresses:
     - 172.20.0.100/24
-  auto-assign: false
+  autoAssign: false
 ---
 apiVersion: metallb.io/v1alpha1
 kind: AddressPool


### PR DESCRIPTION
Signed-off-by: Mohamed Mahmoud <mmahmoud@redhat.com>
```
 k create -f config/samples/metallb.io_v1alpha1_addresspool.yaml 
addresspool.metallb.io/addresspool-sample1 created
addresspool.metallb.io/addresspool-sample2 created
addresspool.metallb.io/addresspool-sample3 created

 k get configmap -n metallb-system config -o yaml
apiVersion: v1
data:
  config: |
    address-pools:
    - name: default
      protocol: layer2
      addresses:
      - 172.18.0.100-172.18.0.255
    - name: gold
      protocol: layer2
      addresses:
      - 172.20.0.100/24
      auto-assign: false
    - name: silver
      protocol: layer2
      addresses:
      - 2002:2:2::1-2002:2:2::100
kind: ConfigMap
metadata:
  creationTimestamp: "2021-07-13T18:20:19Z"
  managedFields:
  - apiVersion: v1
    fieldsType: FieldsV1
    fieldsV1:
      f:data:
        .: {}
        f:config: {}
    manager: main
    operation: Update
    time: "2021-07-13T18:20:19Z"
  name: config
  namespace: metallb-system
  resourceVersion: "1099"
  selfLink: /api/v1/namespaces/metallb-system/configmaps/config
  uid: 45353fda-a8f9-4d37-b019-46d2030d1117
```

```
 go test -v
=== RUN   TestMergeNamespace
--- PASS: TestMergeNamespace (0.00s)
=== RUN   TestMergeDeployment
--- PASS: TestMergeDeployment (0.00s)
=== RUN   TestMergeNilCur
--- PASS: TestMergeNilCur (0.00s)
=== RUN   TestMergeNilMeta
--- PASS: TestMergeNilMeta (0.00s)
=== RUN   TestMergeNilUpd
--- PASS: TestMergeNilUpd (0.00s)
=== RUN   TestMergeService
--- PASS: TestMergeService (0.00s)
=== RUN   TestMergeServiceAccount
--- PASS: TestMergeServiceAccount (0.00s)
=== RUN   TestMergeConfigMapSingleObject
--- PASS: TestMergeConfigMapSingleObject (0.00s)
=== RUN   TestMergeConfigMapMultipleObjects
--- PASS: TestMergeConfigMapMultipleObjects (0.00s)
PASS
ok      github.com/metallb/metallb-operator/pkg/apply   0.021s
```