### PR TITLE
Refactor test to allow usage from other test suites

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ all: manager ## Default make target if no options specified
 test-e2e: generate fmt vet manifests  ## Run e2e tests
 	rm -rf ${TESTS_REPORTS_PATH}
 	mkdir -p ${TESTS_REPORTS_PATH}
-	go test --tags=e2etests -v ./test/e2e -ginkgo.v -junit $(TESTS_REPORTS_PATH) -report $(TESTS_REPORTS_PATH)
+	USE_LOCAL_RESOURCES=true go test --tags=e2etests -v ./test/e2e -ginkgo.v -junit $(TESTS_REPORTS_PATH) -report $(TESTS_REPORTS_PATH)
 
 manager: generate fmt vet  ## Build manager binary
 	go build -ldflags "-X main.build=$$(git rev-parse HEAD)" -o bin/manager main.go


### PR DESCRIPTION
The e2e tests need a few tweaks to be able to be used from other test suites.
The tests are to be used in the cnf project: [here](https://github.com/openshift-kni/cnf-features-deploy/pull/614)