### PR TITLE
Set Multiple AddressPools test inside an It block

### DIFF
--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -427,8 +427,9 @@ var _ = Describe("validation", func() {
 			})
 		})
 	})
-	Context("Testing create/delete Multiple AddressPools", func() {
-		By("Creating first addresspool object ", func() {
+	Context("Creating Multiple AddressPools", func() {
+		It("Testing create/delete Multiple AddressPools", func() {
+			By("Creating first addresspool object ")
 			addresspool := &metallbv1alpha1.AddressPool{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "addresspool1",
@@ -474,10 +475,8 @@ var _ = Describe("validation", func() {
 
 `))
 
-		})
-
-		By("Creating second addresspool object ", func() {
-			addresspool := &metallbv1alpha1.AddressPool{
+			By("Creating second addresspool object ")
+			addresspool = &metallbv1alpha1.AddressPool{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "addresspool2",
 					Namespace: OperatorNameSpace,
@@ -494,7 +493,7 @@ var _ = Describe("validation", func() {
 
 			Expect(testclient.Client.Create(context.Background(), addresspool)).Should(Succeed())
 
-			key := types.NamespacedName{
+			key = types.NamespacedName{
 				Name:      "addresspool2",
 				Namespace: OperatorNameSpace,
 			}
@@ -530,10 +529,9 @@ var _ = Describe("validation", func() {
   - 2.2.2.100
 
 `))
-		})
 
-		By("Deleteing the first addresspool object", func() {
-			addresspool := &metallbv1alpha1.AddressPool{
+			By("Deleteing the first addresspool object")
+			addresspool = &metallbv1alpha1.AddressPool{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "addresspool1",
 					Namespace: OperatorNameSpace,
@@ -573,10 +571,8 @@ var _ = Describe("validation", func() {
 
 `))
 
-		})
-
-		By("Deleteing the second addresspool object", func() {
-			addresspool := &metallbv1alpha1.AddressPool{
+			By("Deleteing the second addresspool object")
+			addresspool = &metallbv1alpha1.AddressPool{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "addresspool2",
 					Namespace: OperatorNameSpace,
@@ -608,14 +604,13 @@ var _ = Describe("validation", func() {
 			}, timeout, interval).Should(MatchYAML(`
 `))
 
+			// Make sure Configmap is deleted at the end of this test
+			By("By checking ConfigMap is deleted at the end of the test")
+			Eventually(func() bool {
+				_, err := testclient.Client.ConfigMaps(OperatorNameSpace).Get(context.Background(), consts.MetalLBConfigMapName, metav1.GetOptions{})
+				return errors.IsNotFound(err)
+			}, timeout, interval).Should(BeTrue())
 		})
-
-		// Make sure Configmap is deleted at the end of this test
-		By("By checking ConfigMap is deleted at the end of the test")
-		Eventually(func() bool {
-			_, err := testclient.Client.ConfigMaps(OperatorNameSpace).Get(context.Background(), consts.MetalLBConfigMapName, metav1.GetOptions{})
-			return errors.IsNotFound(err)
-		}, timeout, interval).Should(BeTrue())
 	})
 })
 

--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -530,7 +530,7 @@ var _ = Describe("validation", func() {
 
 `))
 
-			By("Deleteing the first addresspool object")
+			By("Deleting the first addresspool object")
 			addresspool = &metallbv1alpha1.AddressPool{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "addresspool1",
@@ -571,7 +571,7 @@ var _ = Describe("validation", func() {
 
 `))
 
-			By("Deleteing the second addresspool object")
+			By("Deleting the second addresspool object")
 			addresspool = &metallbv1alpha1.AddressPool{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "addresspool2",


### PR DESCRIPTION
A failing assertion that is not inside an It makes the whole suite panic.

This PR will fix the following panic and will show the test failure error instead.

```
go test --tags=e2etests -v ./test/e2e -ginkgo.v -junit /tmp/test_e2e_logs/ -report /tmp/test_e2e_logs/
=== RUN   TestE2E
STEP: Deleteing the first addresspool object
STEP: By checking ConfigMap matches the expected configuration
--- FAIL: TestE2E (180.03s)
panic: 
Your test failed.
Ginkgo panics to prevent subsequent assertions from running.
Normally Ginkgo rescues this panic so you shouldn't see it.

But, if you make an assertion in a goroutine, Ginkgo can't capture the panic.
To circumvent this, you should call

	defer GinkgoRecover()

at the top of the goroutine that caused this panic.
```
