### PR TITLE
Add bundle-release target and use it in release ci lane

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -33,9 +33,9 @@ jobs:
           make fmt
           git diff --exit-code
 
-      - name: Verify bundle manifests
+      - name: Verify release bundle manifests
         run: |
-          make bundle
+          make bundle-release
           git diff --exit-code
 
       - name: Create and set up K8s Kind Cluster

--- a/Makefile
+++ b/Makefile
@@ -97,7 +97,8 @@ bundle: operator-sdk manifests ## Generate bundle manifests and metadata, then v
 	cd config/manager && $(KUSTOMIZE) edit set image controller=$(IMG)
 	$(KUSTOMIZE) build config/manifests | $(OPERATOR_SDK) generate bundle -q --overwrite --version $(VERSION) $(BUNDLE_METADATA_OPTS) --extra-service-accounts "controller,speaker"
 	$(OPERATOR_SDK) bundle validate ./bundle
-	hack/bump_versions.sh
+
+bundle-release: bundle bump_versions ## Generate the bundle manifests for a release
 
 build-bundle: ## Build the bundle image.
 	docker build -f bundle.Dockerfile -t $(BUNDLE_IMG) .


### PR DESCRIPTION
Running hack/bump_versions.sh in the end of make bundle overrides
what is set by kustomize. This hurts the OLM lane since it
changes the bundle manifests to use local images.
Creating a separate target for release PRs solves this issue.

