### PR TITLE
Remove 'v' from the csv version

### DIFF
--- a/bundle/manifests/metallb-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/metallb-operator.clusterserviceversion.yaml
@@ -377,4 +377,4 @@ spec:
   maturity: alpha
   provider:
     name: Community
-  version: v0.10.2
+  version: 0.10.2

--- a/hack/bump_versions.sh
+++ b/hack/bump_versions.sh
@@ -9,7 +9,7 @@ yq e --inplace '.spec.template.spec.containers[0].env[] |= select (.name=="SPEAK
 yq e --inplace '.spec.template.spec.containers[0].env[] |= select (.name=="CONTROLLER_IMAGE").value|="quay.io/metallb/controller:'$metallb_version'"' config/manager/env.yaml
 
 operator_version=$(cat hack/operator_version.txt)
-csv_version=$operator_version
+csv_version=$(echo "$operator_version" | sed 's/v//')
 if [ $operator_version = "latest" ]; then # operator sdk doesn't like string versions, if we are on main we don't care about the version in the csv
     csv_version="0.0.0" 
 fi


### PR DESCRIPTION
Accroding to the community-operators CI for operatorhub.io the csv version shouldn't include 'v'.

Failing with the following error:
fatal: [localhost]: FAILED! => changed=false
  msg: Operator 'metallb-operator with version 0.10.2' has different version name defined in '/tmp/community-operators-for-catalog/operators/metallb-operator/0.10.2/manifests/metallb-operator.clusterserviceversion.yaml' as 'spec.version' !!!