### PR TITLE
Add AddressPool validation webhook

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -58,7 +58,7 @@ jobs:
 
     - name: Deploy Metal LB Operator
       run: |
-        IMG=${built_image} KUSTOMIZE_DEPLOY_DIR="config/kind-ci/" make deploy
+        IMG=${built_image} KUSTOMIZE_DEPLOY_DIR="config/kind-ci/" ENABLE_OPERATOR_WEBHOOK="true" make deploy
 
     - name: E2E Tests
       run: |

--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,7 @@ endif
 OPERATOR_SDK_VERSION=v1.8.1
 
 OPM_TOOL_URL=https://api.github.com/repos/operator-framework/operator-registry/releases
+CERT_MANAGER_URL=https://github.com/jetstack/cert-manager/releases
 
 TESTS_REPORTS_PATH ?= /tmp/test_e2e_logs/
 VALIDATION_TESTS_REPORTS_PATH ?= /tmp/test_validation_logs/
@@ -83,8 +84,17 @@ uninstall: manifests kustomize  ## Uninstall CRDs from a cluster
 configure-operator-webhook:
 	KUSTOMIZE=$(KUSTOMIZE) hack/configure_operator_webhook.sh
 
+deploy-cert-manager:
+	set -e ;\
+	cert_manager_latest_version=$$(curl -s $(CERT_MANAGER_URL)| grep "title\=\"v" | head -1 | awk -F' ' '{print $$5}' | awk -F'=' '{print $$2}' | xargs) ;\
+	kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/$$cert_manager_latest_version/cert-manager.yaml ;\
+	hack/wait_for_cert_manager.sh ;\
+
 deploy: export ENABLE_OPERATOR_WEBHOOK?=false
 deploy: manifests kustomize configure-operator-webhook ## Deploy controller in the configured cluster
+ifeq ($(ENABLE_OPERATOR_WEBHOOK), true)
+	$(MAKE) deploy-cert-manager
+endif
 	cd config/manager && kustomize edit set image controller=${IMG}
 	$(KUSTOMIZE) build $(KUSTOMIZE_DEPLOY_DIR) | kubectl apply -f -
 	$(KUSTOMIZE) build config/metallb_rbac | kubectl apply -f -

--- a/PROJECT
+++ b/PROJECT
@@ -25,6 +25,10 @@ resources:
   kind: AddressPool
   path: github.com/metallb/metallb-operator/api/v1alpha1
   version: v1alpha1
+  webhooks:
+    defaulting: true
+    validation: true
+    webhookVersion: v1beta1
 - api:
     crdVersion: v1beta1
     namespaced: true

--- a/README.md
+++ b/README.md
@@ -14,12 +14,22 @@ Need to install the following packages
      go get sigs.k8s.io/controller-tools/cmd/controller-gen@v0.3.0
 ```
 
+## AddressPool Validation Webhook
+
+When the AddressPool Validation Webhook is enabled a request to apply an AddressPool with an already defined IP range will be denied.
+
 ## Installation
 
 To install the MetalLB Operator using a prebuilt image, run: 
 
 ```shell
 make deploy
+```
+
+To install the MetalLB Operator using a prebuilt image and enable the AddressPool Validation Webhook, run: 
+
+```shell
+ENABLE_OPERATOR_WEBHOOK=true make deploy
 ```
 
 ## Usage
@@ -42,6 +52,8 @@ metadata:
 ### Quick local installation
 
 A quick, local installation can be done using a kind cluster using a local registry. Follow the steps below to run a locally built metallb-operator on kind.
+
+To enable the AddressPool Validation Webhook set `ENABLE_OPERATOR_WEBHOOK=true`.
 
 **Install and run kind**
 

--- a/api/v1alpha1/addresspool_webhook.go
+++ b/api/v1alpha1/addresspool_webhook.go
@@ -1,0 +1,131 @@
+/*
+
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"context"
+	"fmt"
+	"net"
+
+	"github.com/pkg/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+)
+
+// log is for logging addresspool-webhook.
+var addresspoollog = logf.Log.WithName("addresspool-webhook")
+var c client.Client
+
+func (addressPool *AddressPool) SetupWebhookWithManager(mgr ctrl.Manager) error {
+	c = mgr.GetClient()
+
+	return ctrl.NewWebhookManagedBy(mgr).
+		For(addressPool).
+		Complete()
+}
+
+//+kubebuilder:webhook:verbs=create;update,path=/validate-metallb-io-v1alpha1-addresspool,mutating=false,failurePolicy=fail,groups=metallb.io,resources=addresspools,versions=v1alpha1,name=addresspoolvalidationwebhook.metallb.io
+var _ webhook.Validator = &AddressPool{}
+
+// ValidateCreate implements webhook.Validator so a webhook will be registered for AddressPool.
+func (addressPool *AddressPool) ValidateCreate() error {
+	addresspoollog.Info("validate AddressPool creation", "name", addressPool.Name)
+
+	existingAddressPoolList, err := getExistingAddressPools()
+	if err != nil {
+		return err
+	}
+
+	return addressPool.validateAddressPool(true, existingAddressPoolList)
+}
+
+// ValidateUpdate implements webhook.Validator so a webhook will be registered for AddressPool.
+func (addressPool *AddressPool) ValidateUpdate(old runtime.Object) error {
+	addresspoollog.Info("validate AddressPool update", "name", addressPool.Name)
+
+	existingAddressPoolList, err := getExistingAddressPools()
+	if err != nil {
+		return err
+	}
+
+	return addressPool.validateAddressPool(false, existingAddressPoolList)
+}
+
+// ValidateDelete implements webhook.Validator so a webhook will be registered for AddressPool.
+func (addressPool *AddressPool) ValidateDelete() error {
+	addresspoollog.Info("validate AddressPool deletion", "name", addressPool.Name)
+
+	return nil
+}
+
+func (addressPool *AddressPool) validateAddressPool(isNewAddressPool bool, existingAddressPoolList *AddressPoolList) error {
+	addressPoolCIDRS, err := getAddressPoolCIDRs(addressPool)
+	if err != nil {
+		return errors.Wrapf(err, "Failed to parse addresses for %s", addressPool.Name)
+	}
+
+	for _, existingAddressPool := range existingAddressPoolList.Items {
+		if existingAddressPool.Name == addressPool.Name {
+			// Check that the pool isn't already defined.
+			// Avoid errors when comparing the AddressPool to itself.
+			if isNewAddressPool {
+				return fmt.Errorf("duplicate definition of pool %s", addressPool.Name)
+			} else {
+				continue
+			}
+		}
+
+		existingAddressPoolCIDRS, err := getAddressPoolCIDRs(&existingAddressPool)
+		if err != nil {
+			return errors.Wrapf(err, "Failed to parse addresses for %s", existingAddressPool.Name)
+		}
+
+		// Check that the specified CIDR ranges are not overlapping in existing CIDRs.
+		for _, existingCIDR := range existingAddressPoolCIDRS {
+			for _, cidr := range addressPoolCIDRS {
+				if cidrsOverlap(existingCIDR, cidr) {
+					return fmt.Errorf("CIDR %q in pool %s overlaps with already defined CIDR %q in pool %s", cidr, addressPool.Name, existingCIDR, existingAddressPool.Name)
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func getExistingAddressPools() (*AddressPoolList, error) {
+	existingAddressPoolList := &AddressPoolList{}
+	err := c.List(context.Background(), existingAddressPoolList)
+	if err != nil {
+		return nil, errors.Wrapf(err, "Failed to get existing addresspool objects")
+	}
+	return existingAddressPoolList, nil
+}
+
+func getAddressPoolCIDRs(addressPool *AddressPool) ([]*net.IPNet, error) {
+	var CIDRs []*net.IPNet
+	for _, cidr := range addressPool.Spec.Addresses {
+		nets, err := parseCIDR(cidr)
+		if err != nil {
+			return nil, errors.Wrapf(err, "invalid CIDR %q in pool %s", cidr, addressPool.Name)
+		}
+		CIDRs = append(CIDRs, nets...)
+	}
+	return CIDRs, nil
+}

--- a/api/v1alpha1/addresspool_webhook_test.go
+++ b/api/v1alpha1/addresspool_webhook_test.go
@@ -1,0 +1,177 @@
+package v1alpha1
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	MetalLBTestNameSpace = "metallb-test-namespace"
+)
+
+func TestValidateAddressPool(t *testing.T) {
+	autoAssign := false
+	addressPool := AddressPool{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-addresspool",
+			Namespace: MetalLBTestNameSpace,
+		},
+		Spec: AddressPoolSpec{
+			Protocol: "layer2",
+			Addresses: []string{
+				"1.1.1.1-1.1.1.100",
+			},
+			AutoAssign: &autoAssign,
+		},
+	}
+	addressPoolList := &AddressPoolList{}
+	addressPoolList.Items = append(addressPoolList.Items, addressPool)
+
+	tests := []struct {
+		desc             string
+		addressPool      *AddressPool
+		isNewAddressPool bool
+		expectedError    string
+	}{
+		{
+			desc: "Second AddressPool, already defined name",
+			addressPool: &AddressPool{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-addresspool",
+					Namespace: MetalLBTestNameSpace,
+				},
+				Spec: AddressPoolSpec{
+					Protocol: "layer2",
+					Addresses: []string{
+						"1.1.1.101-1.1.1.200",
+					},
+					AutoAssign: &autoAssign,
+				},
+			},
+			isNewAddressPool: true,
+			expectedError:    "duplicate definition of pool",
+		},
+		{
+			desc: "Second AddressPool, overlapping addresses defined by address range",
+			addressPool: &AddressPool{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-addresspool2",
+					Namespace: MetalLBTestNameSpace,
+				},
+				Spec: AddressPoolSpec{
+					Protocol: "layer2",
+					Addresses: []string{
+						"1.1.1.15-1.1.1.20",
+					},
+					AutoAssign: &autoAssign,
+				},
+			},
+			isNewAddressPool: true,
+			expectedError:    "overlaps with already defined CIDR",
+		},
+		{
+			desc: "Second AddressPool, overlapping addresses defined by network prefix",
+			addressPool: &AddressPool{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-addresspool2",
+					Namespace: MetalLBTestNameSpace,
+				},
+				Spec: AddressPoolSpec{
+					Protocol: "layer2",
+					Addresses: []string{
+						"1.1.1.0/24",
+					},
+					AutoAssign: &autoAssign,
+				},
+			},
+			isNewAddressPool: true,
+			expectedError:    "overlaps with already defined CIDR",
+		},
+		{
+			desc: "Second AddressPool, invalid CIDR, single address provided while expecting a range",
+			addressPool: &AddressPool{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-addresspool2",
+					Namespace: MetalLBTestNameSpace,
+				},
+				Spec: AddressPoolSpec{
+					Protocol: "layer2",
+					Addresses: []string{
+						"1.1.1.15",
+					},
+					AutoAssign: &autoAssign,
+				},
+			},
+			isNewAddressPool: true,
+			expectedError:    "invalid CIDR",
+		},
+		{
+			desc: "Second AddressPool, invalid CIDR, first address of the range is after the second",
+			addressPool: &AddressPool{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-addresspool2",
+					Namespace: MetalLBTestNameSpace,
+				},
+				Spec: AddressPoolSpec{
+					Protocol: "layer2",
+					Addresses: []string{
+						"1.1.1.200-1.1.1.101",
+					},
+					AutoAssign: &autoAssign,
+				},
+			},
+			isNewAddressPool: true,
+			expectedError:    "invalid IP range",
+		},
+		{
+			desc: "Second AddressPool, invalid ipv6 CIDR, single address provided while expecting a range",
+			addressPool: &AddressPool{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-addresspool2",
+					Namespace: MetalLBTestNameSpace,
+				},
+				Spec: AddressPoolSpec{
+					Protocol: "layer2",
+					Addresses: []string{
+						"2000::",
+					},
+					AutoAssign: &autoAssign,
+				},
+			},
+			isNewAddressPool: true,
+			expectedError:    "invalid CIDR",
+		},
+		{
+			desc: "Second AddressPool, invalid ipv6 CIDR, first address of the range is after the second",
+			addressPool: &AddressPool{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-addresspool2",
+					Namespace: MetalLBTestNameSpace,
+				},
+				Spec: AddressPoolSpec{
+					Protocol: "layer2",
+					Addresses: []string{
+						"2000:::ffff-2000::",
+					},
+					AutoAssign: &autoAssign,
+				},
+			},
+			isNewAddressPool: true,
+			expectedError:    "invalid IP range",
+		},
+	}
+
+	for _, test := range tests {
+		err := test.addressPool.validateAddressPool(test.isNewAddressPool, addressPoolList)
+		if err == nil {
+			t.Errorf("%s: ValidateAddressPool failed, no error found while expected: \"%s\"", test.desc, test.expectedError)
+		} else {
+			if !strings.Contains(fmt.Sprint(err), test.expectedError) {
+				t.Errorf("%s: ValidateAddressPool failed, expected error: \"%s\" to contain: \"%s\"", test.desc, err, test.expectedError)
+			}
+		}
+	}
+}

--- a/api/v1alpha1/validate_cidrs.go
+++ b/api/v1alpha1/validate_cidrs.go
@@ -1,0 +1,83 @@
+/*
+
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"bytes"
+	"fmt"
+	"net"
+	"strings"
+
+	"github.com/mikioh/ipaddr"
+)
+
+// This code is taken from MetalLB config:
+// https://github.com/metallb/metallb/blob/main/internal/config/config.go
+// TODO: refactor when moving the crds and the webhook to MetalLB.
+
+func parseCIDR(cidr string) ([]*net.IPNet, error) {
+	if !strings.Contains(cidr, "-") {
+		_, n, err := net.ParseCIDR(cidr)
+		if err != nil {
+			return nil, fmt.Errorf("invalid CIDR %q", cidr)
+		}
+		return []*net.IPNet{n}, nil
+	}
+
+	fs := strings.SplitN(cidr, "-", 2)
+	if len(fs) != 2 {
+		return nil, fmt.Errorf("invalid IP range %q", cidr)
+	}
+	start := net.ParseIP(strings.TrimSpace(fs[0]))
+	if start == nil {
+		return nil, fmt.Errorf("invalid IP range %q: invalid start IP %q", cidr, fs[0])
+	}
+	end := net.ParseIP(strings.TrimSpace(fs[1]))
+	if end == nil {
+		return nil, fmt.Errorf("invalid IP range %q: invalid end IP %q", cidr, fs[1])
+	}
+
+	if bytes.Compare(start, end) >= 0 {
+		return nil, fmt.Errorf("invalid IP range %q: start IP %q is after the end IP %q", cidr, start, end)
+	}
+
+	var ret []*net.IPNet
+	for _, pfx := range ipaddr.Summarize(start, end) {
+		n := &net.IPNet{
+			IP:   pfx.IP,
+			Mask: pfx.Mask,
+		}
+		ret = append(ret, n)
+	}
+	return ret, nil
+}
+
+func cidrsOverlap(a, b *net.IPNet) bool {
+	return cidrContainsCIDR(a, b) || cidrContainsCIDR(b, a)
+}
+
+func cidrContainsCIDR(outer, inner *net.IPNet) bool {
+	ol, _ := outer.Mask.Size()
+	il, _ := inner.Mask.Size()
+	if ol == il && outer.IP.Equal(inner.IP) {
+		return true
+	}
+	if ol < il && outer.Contains(inner.IP) {
+		return true
+	}
+	return false
+}

--- a/bundle/manifests/metallb-operator-webhook-service_v1_service.yaml
+++ b/bundle/manifests/metallb-operator-webhook-service_v1_service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: null
+  name: metallb-operator-webhook-service
+spec:
+  ports:
+  - port: 443
+    targetPort: 9443
+  selector:
+    control-plane: controller-manager
+status:
+  loadBalancer: {}

--- a/bundle/manifests/metallb-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/metallb-operator.clusterserviceversion.yaml
@@ -326,17 +326,32 @@ spec:
                         value: quay.io/metallb/speaker:main
                       - name: CONTROLLER_IMAGE
                         value: quay.io/metallb/controller:main
+                      - name: ENABLE_OPERATOR_WEBHOOK
+                        value: "true"
                       - name: WATCH_NAMESPACE
                         valueFrom:
                           fieldRef:
                             fieldPath: metadata.annotations['olm.targetNamespaces']
                     image: quay.io/metallb/metallb-operator:latest
                     name: manager
+                    ports:
+                      - containerPort: 9443
+                        name: webhook-server
+                        protocol: TCP
                     resources:
                       requests:
                         cpu: 50m
                         memory: 20Mi
+                    volumeMounts:
+                      - mountPath: /tmp/k8s-webhook-server/serving-certs
+                        name: cert
+                        readOnly: true
                 terminationGracePeriodSeconds: 10
+                volumes:
+                  - name: cert
+                    secret:
+                      defaultMode: 420
+                      secretName: webhook-server-cert
       permissions:
         - rules:
             - apiGroups:
@@ -462,3 +477,25 @@ spec:
   provider:
     name: Community
   version: 0.0.0
+  webhookdefinitions:
+    - admissionReviewVersions:
+        - v1
+        - vibeta1
+      containerPort: 443
+      deploymentName: metallb-operator-controller-manager
+      failurePolicy: Fail
+      generateName: addresspoolvalidationwebhook.metallb.io
+      rules:
+        - apiGroups:
+            - metallb.io
+          apiVersions:
+            - v1alpha1
+          operations:
+            - CREATE
+            - UPDATE
+          resources:
+            - addresspools
+      sideEffects: None
+      targetPort: 9443
+      type: ValidatingAdmissionWebhook
+      webhookPath: /validate-metallb-io-v1alpha1-addresspool

--- a/config/certmanager/certificate.yaml
+++ b/config/certmanager/certificate.yaml
@@ -1,0 +1,25 @@
+# The following manifests contain a self-signed issuer CR and a certificate CR.
+# More document can be found at https://docs.cert-manager.io
+# WARNING: Targets CertManager v1.0. Check https://cert-manager.io/docs/installation/upgrading/ for breaking changes.
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: selfsigned-issuer
+  namespace: system
+spec:
+  selfSigned: {}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: serving-cert  # this name should match the one appeared in kustomizeconfig.yaml
+  namespace: system
+spec:
+  # $(SERVICE_NAME) and $(SERVICE_NAMESPACE) will be substituted by kustomize
+  dnsNames:
+  - $(SERVICE_NAME).$(SERVICE_NAMESPACE).svc
+  - $(SERVICE_NAME).$(SERVICE_NAMESPACE).svc.cluster.local
+  issuerRef:
+    kind: Issuer
+    name: selfsigned-issuer
+  secretName: webhook-server-cert # this secret will not be prefixed, since it's not managed by kustomize

--- a/config/certmanager/kustomization.yaml
+++ b/config/certmanager/kustomization.yaml
@@ -1,0 +1,5 @@
+resources:
+- certificate.yaml
+
+configurations:
+- kustomizeconfig.yaml

--- a/config/certmanager/kustomizeconfig.yaml
+++ b/config/certmanager/kustomizeconfig.yaml
@@ -1,0 +1,16 @@
+# This configuration is for teaching kustomize how to update name ref and var substitution 
+nameReference:
+- kind: Issuer
+  group: cert-manager.io
+  fieldSpecs:
+  - kind: Certificate
+    group: cert-manager.io
+    path: spec/issuerRef/name
+
+varReference:
+- kind: Certificate
+  group: cert-manager.io
+  path: spec/commonName
+- kind: Certificate
+  group: cert-manager.io
+  path: spec/dnsNames

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -19,3 +19,39 @@ resources:
 - ../crd
 - ../rbac
 - ../manager
+- ../webhook
+- ../certmanager
+
+patchesStrategicMerge:
+- manager_webhook_patch.yaml
+- webhookcainjection_patch.yaml
+
+# the following config is for teaching kustomize how to do var substitution
+vars:
+# [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER' prefix.
+- name: CERTIFICATE_NAMESPACE # namespace of the certificate CR
+  objref:
+    kind: Certificate
+    group: cert-manager.io
+    version: v1
+    name: serving-cert # this name should match the one in certificate.yaml
+  fieldref:
+    fieldpath: metadata.namespace
+- name: CERTIFICATE_NAME
+  objref:
+    kind: Certificate
+    group: cert-manager.io
+    version: v1
+    name: serving-cert # this name should match the one in certificate.yaml
+- name: SERVICE_NAMESPACE # namespace of the service
+  objref:
+    kind: Service
+    version: v1
+    name: webhook-service
+  fieldref:
+    fieldpath: metadata.namespace
+- name: SERVICE_NAME
+  objref:
+    kind: Service
+    version: v1
+    name: webhook-service

--- a/config/default/manager_webhook_patch.yaml
+++ b/config/default/manager_webhook_patch.yaml
@@ -1,0 +1,23 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: controller-manager
+  namespace: system
+spec:
+  template:
+    spec:
+      containers:
+      - name: manager
+        ports:
+        - containerPort: 9443
+          name: webhook-server
+          protocol: TCP
+        volumeMounts:
+        - mountPath: /tmp/k8s-webhook-server/serving-certs
+          name: cert
+          readOnly: true
+      volumes:
+      - name: cert
+        secret:
+          defaultMode: 420
+          secretName: webhook-server-cert

--- a/config/default/webhookcainjection_patch.yaml
+++ b/config/default/webhookcainjection_patch.yaml
@@ -1,0 +1,8 @@
+# This patch add annotation to admission webhook config and
+# the variables $(CERTIFICATE_NAMESPACE) and $(CERTIFICATE_NAME) will be substituted by kustomize.
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: addresspoolvalidationwebhook.metallb.io
+  annotations:
+    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)

--- a/config/manager/env.yaml
+++ b/config/manager/env.yaml
@@ -13,3 +13,5 @@ spec:
               value: "quay.io/metallb/speaker:main"
             - name: CONTROLLER_IMAGE
               value: "quay.io/metallb/controller:main"
+            - name: ENABLE_OPERATOR_WEBHOOK
+              value: "true"

--- a/config/webhook/kustomization.yaml
+++ b/config/webhook/kustomization.yaml
@@ -1,0 +1,6 @@
+resources:
+- manifests.yaml
+- service.yaml
+
+configurations:
+- kustomizeconfig.yaml

--- a/config/webhook/kustomizeconfig.yaml
+++ b/config/webhook/kustomizeconfig.yaml
@@ -1,0 +1,18 @@
+# the following config is for teaching kustomize where to look at when substituting vars.
+# It requires kustomize v2.1.0 or newer to work properly.
+nameReference:
+- kind: Service
+  version: v1
+  fieldSpecs:
+  - kind: ValidatingWebhookConfiguration
+    group: admissionregistration.k8s.io
+    path: webhooks/clientConfig/service/name
+
+namespace:
+- kind: ValidatingWebhookConfiguration
+  group: admissionregistration.k8s.io
+  path: webhooks/clientConfig/service/namespace
+  create: true
+
+varReference:
+- path: metadata/annotations

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -1,0 +1,28 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  creationTimestamp: null
+  name: addresspoolvalidationwebhook.metallb.io
+webhooks:
+- clientConfig:
+    caBundle: Cg==
+    service:
+      name: webhook-service
+      namespace: system
+      path: /validate-metallb-io-v1alpha1-addresspool
+  failurePolicy: Fail
+  name: addresspoolvalidationwebhook.metallb.io
+  sideEffects: None
+  admissionReviewVersions:
+  - v1
+  - vibeta1
+  rules:
+  - apiGroups:
+    - metallb.io
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - addresspools

--- a/config/webhook/service.yaml
+++ b/config/webhook/service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: webhook-service
+  namespace: system
+spec:
+  ports:
+    - port: 443
+      targetPort: 9443
+  selector:
+    control-plane: controller-manager

--- a/controllers/addresspool_controller_test.go
+++ b/controllers/addresspool_controller_test.go
@@ -2,6 +2,8 @@ package controllers
 
 import (
 	"context"
+	"time"
+
 	"github.com/metallb/metallb-operator/api/v1alpha1"
 	"github.com/metallb/metallb-operator/pkg/apply"
 	. "github.com/onsi/ginkgo"
@@ -10,7 +12,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"time"
 )
 
 var _ = Describe("AddressPool Controller", func() {
@@ -31,8 +32,7 @@ var _ = Describe("AddressPool Controller", func() {
 				Spec: v1alpha1.AddressPoolSpec{
 					Protocol: "layer2",
 					Addresses: []string{
-						"1.1.1.1",
-						"1.1.1.100",
+						"1.1.1.1-1.1.1.100",
 					},
 					AutoAssign: &autoAssign,
 				},
@@ -45,8 +45,7 @@ var _ = Describe("AddressPool Controller", func() {
 				Spec: v1alpha1.AddressPoolSpec{
 					Protocol: "layer2",
 					Addresses: []string{
-						"2.2.2.2",
-						"2.2.2.100",
+						"2.2.2.2-2.2.2.100",
 					},
 					AutoAssign: &autoAssign,
 				},
@@ -67,8 +66,7 @@ var _ = Describe("AddressPool Controller", func() {
   protocol: layer2
   auto-assign: false
   addresses:
-  - 1.1.1.1
-  - 1.1.1.100
+  - 1.1.1.1-1.1.1.100
 `))
 			By("Creating 2nd AddressPool resource")
 			err = k8sClient.Create(context.Background(), addressPool2)
@@ -86,14 +84,12 @@ var _ = Describe("AddressPool Controller", func() {
   protocol: layer2
   auto-assign: false
   addresses:
-  - 1.1.1.1
-  - 1.1.1.100
+  - 1.1.1.1-1.1.1.100
 - name: test-addresspool2
   protocol: layer2
   auto-assign: false
   addresses:
-  - 2.2.2.2
-  - 2.2.2.100
+  - 2.2.2.2-2.2.2.100
 `))
 			By("Deleting 1st AddressPool resource")
 			err = k8sClient.Delete(context.Background(), addressPool1)
@@ -111,8 +107,7 @@ var _ = Describe("AddressPool Controller", func() {
   protocol: layer2
   auto-assign: false
   addresses:
-  - 2.2.2.2
-  - 2.2.2.100
+  - 2.2.2.2-2.2.2.100
 
 `))
 			By("Deleting 2nd AddressPool resource")

--- a/controllers/bgppeer_controller_test.go
+++ b/controllers/bgppeer_controller_test.go
@@ -2,6 +2,8 @@ package controllers
 
 import (
 	"context"
+	"time"
+
 	"github.com/metallb/metallb-operator/api/v1alpha1"
 	"github.com/metallb/metallb-operator/pkg/apply"
 	. "github.com/onsi/ginkgo"
@@ -10,7 +12,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"time"
 )
 
 var _ = Describe("Peer Controller", func() {
@@ -169,8 +170,7 @@ var _ = Describe("Peer Controller", func() {
 				Spec: v1alpha1.AddressPoolSpec{
 					Protocol: "bgp",
 					Addresses: []string{
-						"1.1.1.1",
-						"1.1.1.100",
+						"1.1.1.1-1.1.1.100",
 					},
 					AutoAssign: &autoAssign,
 					BGPAdvertisements: []v1alpha1.BgpAdvertisement{
@@ -193,8 +193,7 @@ var _ = Describe("Peer Controller", func() {
 				Spec: v1alpha1.AddressPoolSpec{
 					Protocol: "bgp",
 					Addresses: []string{
-						"2.2.2.2",
-						"2.2.2.100",
+						"2.2.2.2-2.2.2.100",
 					},
 					AutoAssign: &autoAssign,
 				},
@@ -239,8 +238,7 @@ var _ = Describe("Peer Controller", func() {
 - name: test-addresspool1
   protocol: bgp
   addresses:
-  - 1.1.1.1
-  - 1.1.1.100
+  - 1.1.1.1-1.1.1.100
   auto-assign: false
   bgp-advertisements: 
   - communities: 
@@ -265,8 +263,7 @@ var _ = Describe("Peer Controller", func() {
 - name: test-addresspool1
   protocol: bgp
   addresses:
-  - 1.1.1.1
-  - 1.1.1.100
+  - 1.1.1.1-1.1.1.100
   auto-assign: false
   bgp-advertisements: 
   - communities: 
@@ -295,8 +292,7 @@ peers:
 - name: test-addresspool1
   protocol: bgp
   addresses:
-  - 1.1.1.1
-  - 1.1.1.100
+  - 1.1.1.1-1.1.1.100
   auto-assign: false
   bgp-advertisements: 
   - communities: 
@@ -307,8 +303,7 @@ peers:
 - name: test-addresspool2
   protocol: bgp
   addresses:
-  - 2.2.2.2
-  - 2.2.2.100
+  - 2.2.2.2-2.2.2.100
   auto-assign: false
 peers:
 - my-asn: 64500
@@ -331,8 +326,7 @@ peers:
 - name: test-addresspool1
   protocol: bgp
   addresses:
-  - 1.1.1.1
-  - 1.1.1.100
+  - 1.1.1.1-1.1.1.100
   auto-assign: false
   bgp-advertisements: 
   - communities: 
@@ -343,8 +337,7 @@ peers:
 - name: test-addresspool2
   protocol: bgp
   addresses:
-  - 2.2.2.2
-  - 2.2.2.100
+  - 2.2.2.2-2.2.2.100
   auto-assign: false
 peers:
 - my-asn: 64500
@@ -372,8 +365,7 @@ peers:
 - name: test-addresspool1
   protocol: bgp
   addresses:
-  - 1.1.1.1
-  - 1.1.1.100
+  - 1.1.1.1-1.1.1.100
   auto-assign: false
   bgp-advertisements: 
   - communities: 
@@ -384,8 +376,7 @@ peers:
 - name: test-addresspool2
   protocol: bgp
   addresses:
-  - 2.2.2.2
-  - 2.2.2.100
+  - 2.2.2.2-2.2.2.100
   auto-assign: false
 peers:
 - my-asn: 64000
@@ -408,8 +399,7 @@ peers:
 - name: test-addresspool2
   protocol: bgp
   addresses:
-  - 2.2.2.2
-  - 2.2.2.100
+  - 2.2.2.2-2.2.2.100
   auto-assign: false
 peers:
 - my-asn: 64000
@@ -436,8 +426,7 @@ peers:
 - name: test-addresspool2
   protocol: bgp
   addresses:
-  - 2.2.2.2
-  - 2.2.2.100
+  - 2.2.2.2-2.2.2.100
   auto-assign: false
 `))
 			By("Deleting 2nd AddressPool resource")

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
 	github.com/huandu/xstrings v1.3.2 // indirect
 	github.com/kennygrant/sanitize v1.2.4
+	github.com/mikioh/ipaddr v0.0.0-20190404000644-d465c8ab6721
 	github.com/mitchellh/copystructure v1.2.0 // indirect
 	github.com/onsi/ginkgo v1.14.1
 	github.com/onsi/gomega v1.10.2

--- a/go.sum
+++ b/go.sum
@@ -401,6 +401,8 @@ github.com/mholt/certmagic v0.6.2-0.20190624175158-6a42ef9fe8c2/go.mod h1:g4cOPx
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
 github.com/miekg/dns v1.1.3/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
 github.com/miekg/dns v1.1.4/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
+github.com/mikioh/ipaddr v0.0.0-20190404000644-d465c8ab6721 h1:RlZweED6sbSArvlE924+mUcZuXKLBHA35U7LN621Bws=
+github.com/mikioh/ipaddr v0.0.0-20190404000644-d465c8ab6721/go.mod h1:Ickgr2WtCLZ2MDGd4Gr0geeCH5HybhRJbonOgQpvSxc=
 github.com/mindprince/gonvml v0.0.0-20190828220739-9ebdce4bb989/go.mod h1:2eu9pRWp8mo84xCg6KswZ+USQHjwgRhNp06sozOdsTY=
 github.com/mistifyio/go-zfs v2.1.2-0.20190413222219-f784269be439+incompatible/go.mod h1:8AuVvqP/mXw1px98n46wfvcGfQ4ci2FwoAjKYxuo3Z4=
 github.com/mitchellh/cli v1.0.0/go.mod h1:hNIlj7HEI86fIcpObd7a0FcrxTWetlwJDGcceTlRvqc=

--- a/hack/configure_operator_webhook.sh
+++ b/hack/configure_operator_webhook.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+
+ENABLE_OPERATOR_WEBHOOK="${ENABLE_OPERATOR_WEBHOOK:-true}"
+WEBHOOK_CONFIG_FILE="${WEBHOOK_CONFIG_FILE:-config/default/kustomization.yaml}"
+KUSTOMIZE="${KUSTOMIZE:-kustomize}"
+
+HAS_WEBHOOK_CONFIGURATION=$(${KUSTOMIZE} build config/default | grep "ValidatingWebhookConfiguration")
+
+if [ "${ENABLE_OPERATOR_WEBHOOK}" = "true" ]; then
+  # if webhook is not configured, add webhook configuration
+  if [ -z "${HAS_WEBHOOK_CONFIGURATION}" ]; then
+    cat >> "${WEBHOOK_CONFIG_FILE}" << EOF
+- ../webhook
+- ../certmanager
+
+patchesStrategicMerge:
+- manager_webhook_patch.yaml
+- webhookcainjection_patch.yaml
+
+# the following config is for teaching kustomize how to do var substitution
+vars:
+# [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER' prefix.
+- name: CERTIFICATE_NAMESPACE # namespace of the certificate CR
+  objref:
+    kind: Certificate
+    group: cert-manager.io
+    version: v1
+    name: serving-cert # this name should match the one in certificate.yaml
+  fieldref:
+    fieldpath: metadata.namespace
+- name: CERTIFICATE_NAME
+  objref:
+    kind: Certificate
+    group: cert-manager.io
+    version: v1
+    name: serving-cert # this name should match the one in certificate.yaml
+- name: SERVICE_NAMESPACE # namespace of the service
+  objref:
+    kind: Service
+    version: v1
+    name: webhook-service
+  fieldref:
+    fieldpath: metadata.namespace
+- name: SERVICE_NAME
+  objref:
+    kind: Service
+    version: v1
+    name: webhook-service
+EOF
+  fi
+else
+  # if webhook is configured, remove webhook configuration
+  if [ -n "${HAS_WEBHOOK_CONFIGURATION}" ]; then
+    webhook_config_first_line=$(grep --text -n "webhook" "${WEBHOOK_CONFIG_FILE}" | cut -f1 -d: | sort -n | head -n1)
+    sed -i ''"${webhook_config_first_line}"',$d' "${WEBHOOK_CONFIG_FILE}"
+  fi
+fi
+
+yq e --inplace '.spec.template.spec.containers[0].env[] |= select (.name=="ENABLE_OPERATOR_WEBHOOK").value|="'${ENABLE_OPERATOR_WEBHOOK}'"' config/manager/env.yaml

--- a/hack/self_signed_cert.yaml
+++ b/hack/self_signed_cert.yaml
@@ -1,0 +1,6 @@
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: selfsigned-issuer-test
+spec:
+  selfSigned: {}

--- a/hack/wait_for_cert_manager.sh
+++ b/hack/wait_for_cert_manager.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+NAMESPACE=${NAMESPACE:-"cert-manager"}
+
+ATTEMPTS=0
+MAX_ATTEMPTS=60
+cert_manager_ready=false
+until $cert_manager_ready || [ $ATTEMPTS -eq $MAX_ATTEMPTS ]
+do
+    echo "waiting for cert-manager to be ready attempt:${ATTEMPTS}"
+    kubectl apply -f hack/self_signed_cert.yaml
+    if [[ $? != 0 ]]; then
+        echo "failed, retrying"
+        sleep 5
+    else
+        echo "cert-manager is ready"
+        cert_manager_ready=true
+        kubectl delete -f hack/self_signed_cert.yaml
+    fi
+    (( ATTEMPTS++ ))
+done
+
+if ! $cert_manager_ready; then
+    echo "Timed out waiting for cert-manage to be ready"
+    exit 1
+fi

--- a/main.go
+++ b/main.go
@@ -125,6 +125,13 @@ func main() {
 		setupLog.Error(err, "unable to create controller", "controller", "BGPPeer")
 		os.Exit(1)
 	}
+
+	if os.Getenv("ENABLE_OPERATOR_WEBHOOK") == "true" {
+		if err = (&metallbv1alpha1.AddressPool{}).SetupWebhookWithManager(mgr); err != nil {
+			setupLog.Error(err, "unable to create webhook", "webhook", "AddressPool")
+			os.Exit(1)
+		}
+	}
 	// +kubebuilder:scaffold:builder
 
 	setupLog.Info("starting manager")

--- a/test/consts/const.go
+++ b/test/consts/const.go
@@ -23,4 +23,6 @@ const (
 	MetalLBConfigMapName = apply.MetalLBConfigMap
 	// DefaultOperatorNameSpace is the default operator namespace
 	DefaultOperatorNameSpace = "metallb-system"
+	// AddressPoolValidationWebhookName contains the name of the AddressPool validation webhook
+	AddressPoolValidationWebhookName = "addresspoolvalidationwebhook.metallb.io"
 )

--- a/test/e2e/functional/tests/e2e.go
+++ b/test/e2e/functional/tests/e2e.go
@@ -2,7 +2,9 @@ package tests
 
 import (
 	"context"
+	"fmt"
 	"os"
+	"strings"
 	"time"
 
 	. "github.com/onsi/ginkgo"
@@ -15,6 +17,7 @@ import (
 	"github.com/metallb/metallb-operator/test/consts"
 	testclient "github.com/metallb/metallb-operator/test/e2e/client"
 	metallbutils "github.com/metallb/metallb-operator/test/e2e/metallb"
+	admv1 "k8s.io/api/admissionregistration/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -717,5 +720,123 @@ var _ = Describe("metallb", func() {
   peer-asn: 60501
   router-id: 11.11.11.11 
 `))
+	})
+
+	Context("Validate AddressPool Webhook", func() {
+		BeforeEach(func() {
+			By("Checking if validation webhook is enabled")
+			deploy, err := testclient.Client.Deployments(OperatorNameSpace).Get(context.Background(), consts.MetalLBOperatorDeploymentName, metav1.GetOptions{})
+			Expect(err).ToNot(HaveOccurred())
+
+			isValidationWebhookEnabled := false
+			for _, container := range deploy.Spec.Template.Spec.Containers {
+				if container.Name == "manager" {
+					for _, env := range container.Env {
+						if env.Name == "ENABLE_OPERATOR_WEBHOOK" {
+							if env.Value == "true" {
+								isValidationWebhookEnabled = true
+							}
+						}
+					}
+				}
+			}
+
+			if !isValidationWebhookEnabled {
+				Skip("AddressPool webhook is disabled")
+			}
+
+			By("Checking if validation webhook is running")
+			// Can't just check the ValidatingWebhookConfiguration name as it's changing between different deployment methods.
+			// Need to check the webhook name in the webhooks definition of the ValidatingWebhookConfiguration.
+			validateCfgList := &admv1.ValidatingWebhookConfigurationList{}
+			err = testclient.Client.List(context.TODO(), validateCfgList, &goclient.ListOptions{})
+			Expect(err).ToNot(HaveOccurred())
+
+			isValidationWebhookRunning := false
+			for _, validateCfg := range validateCfgList.Items {
+				for _, webhook := range validateCfg.Webhooks {
+					if webhook.Name == consts.AddressPoolValidationWebhookName {
+						isValidationWebhookRunning = true
+					}
+				}
+			}
+			Expect(isValidationWebhookRunning).To(BeTrue(), "AddressPool webhook is not running")
+		})
+		It("Should recognize overlapping addresses in two AddressPools", func() {
+			By("Creating first AddressPool resource")
+			autoAssign := false
+			firstAddressPool := &metallbv1alpha1.AddressPool{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-addresspool",
+					Namespace: OperatorNameSpace,
+				},
+				Spec: metallbv1alpha1.AddressPoolSpec{
+					Protocol: "layer2",
+					Addresses: []string{
+						"1.1.1.1-1.1.1.100",
+					},
+					AutoAssign: &autoAssign,
+				},
+			}
+			err := testclient.Client.Create(context.Background(), firstAddressPool)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("Creating second AddressPool resource with overlapping addresses defined by address range")
+			secondAdressPool := &metallbv1alpha1.AddressPool{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-addresspool2",
+					Namespace: OperatorNameSpace,
+				},
+				Spec: metallbv1alpha1.AddressPoolSpec{
+					Protocol: "layer2",
+					Addresses: []string{
+						"1.1.1.15-1.1.1.20",
+					},
+					AutoAssign: &autoAssign,
+				},
+			}
+
+			err = testclient.Client.Create(context.Background(), secondAdressPool)
+			Expect(err).ToNot(BeNil())
+			if !strings.Contains(fmt.Sprint(err), "overlaps with already defined CIDR") {
+				Expect(err).ToNot(HaveOccurred())
+			}
+
+			By("Creating second valid AddressPool resource")
+			secondAdressPool.Spec.Addresses = []string{
+				"1.1.1.101-1.1.1.200",
+			}
+			err = testclient.Client.Create(context.Background(), secondAdressPool)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("Updating second AddressPool addresses to overlapping addresses defined by network prefix")
+			secondAdressPool.Spec.Addresses = []string{
+				"1.1.1.0/24",
+			}
+			err = testclient.Client.Update(context.Background(), secondAdressPool)
+			Expect(err).ToNot(BeNil())
+			if !strings.Contains(fmt.Sprint(err), "overlaps with already defined CIDR") {
+				Expect(err).ToNot(HaveOccurred())
+			}
+
+			By("Deleting first AddressPool resource")
+			err = testclient.Client.Delete(context.Background(), firstAddressPool)
+			Expect(err).ToNot(HaveOccurred())
+
+			Eventually(func() bool {
+				err := testclient.Client.Get(context.Background(), goclient.ObjectKey{Namespace: firstAddressPool.Namespace, Name: firstAddressPool.Name}, firstAddressPool)
+				return errors.IsNotFound(err)
+			}, 1*time.Minute, 5*time.Second).Should(BeTrue(), "Failed to delete first AddressPool resource")
+
+			By("Deleting second AddressPool resource")
+			err = testclient.Client.Delete(context.Background(), secondAdressPool)
+			Expect(err).ToNot(HaveOccurred())
+
+			Eventually(func() bool {
+				err := testclient.Client.Get(context.Background(), goclient.ObjectKey{Namespace: secondAdressPool.Namespace, Name: secondAdressPool.Name}, secondAdressPool)
+				return errors.IsNotFound(err)
+			}, 1*time.Minute, 5*time.Second).Should(BeTrue(), "Failed to delete second AddressPool resource")
+
+		})
 	})
 })

--- a/test/e2e/functional/tests/e2e.go
+++ b/test/e2e/functional/tests/e2e.go
@@ -194,16 +194,14 @@ var _ = Describe("metallb", func() {
 				Spec: metallbv1alpha1.AddressPoolSpec{
 					Protocol: "layer2",
 					Addresses: []string{
-						"1.1.1.1",
-						"1.1.1.100",
+						"1.1.1.1-1.1.1.100",
 					},
 				},
 			}, `address-pools:
 - name: addresspool1
   protocol: layer2
   addresses:
-  - 1.1.1.1
-  - 1.1.1.100
+  - 1.1.1.1-1.1.1.100
 `),
 			table.Entry("Test AddressPool object with auto assign set to false", "addresspool2", &metallbv1alpha1.AddressPool{
 				ObjectMeta: metav1.ObjectMeta{
@@ -213,8 +211,7 @@ var _ = Describe("metallb", func() {
 				Spec: metallbv1alpha1.AddressPoolSpec{
 					Protocol: "layer2",
 					Addresses: []string{
-						"2.2.2.1",
-						"2.2.2.100",
+						"2.2.2.1-2.2.2.100",
 					},
 					AutoAssign: &autoAssign,
 				},
@@ -223,8 +220,7 @@ var _ = Describe("metallb", func() {
   protocol: layer2
   auto-assign: false
   addresses:
-  - 2.2.2.1
-  - 2.2.2.100
+  - 2.2.2.1-2.2.2.100
 `),
 			table.Entry("Test AddressPool object with bgp-advertisements", "addresspool3", &metallbv1alpha1.AddressPool{
 				ObjectMeta: metav1.ObjectMeta{
@@ -234,8 +230,7 @@ var _ = Describe("metallb", func() {
 				Spec: metallbv1alpha1.AddressPoolSpec{
 					Protocol: "bgp",
 					Addresses: []string{
-						"3.3.3.1",
-						"3.3.3.100",
+						"3.3.3.1-3.3.3.100",
 					},
 					AutoAssign: &autoAssign,
 					BGPAdvertisements: []metallbv1alpha1.BgpAdvertisement{
@@ -254,9 +249,7 @@ var _ = Describe("metallb", func() {
   protocol: bgp
   auto-assign: false
   addresses:
-
-  - 3.3.3.1
-  - 3.3.3.100
+  - 3.3.3.1-3.3.3.100
   bgp-advertisements: 
   - communities: 
     - 65535:65282
@@ -363,8 +356,7 @@ var _ = Describe("metallb", func() {
 					Spec: metallbv1alpha1.AddressPoolSpec{
 						Protocol: "layer2",
 						Addresses: []string{
-							"1.1.1.1",
-							"1.1.1.100",
+							"1.1.1.1-1.1.1.100",
 						},
 					},
 				}
@@ -392,8 +384,7 @@ var _ = Describe("metallb", func() {
 - name: addresspool1
   protocol: layer2
   addresses:
-  - 1.1.1.1
-  - 1.1.1.100
+  - 1.1.1.1-1.1.1.100
 `))
 
 			})
@@ -407,8 +398,7 @@ var _ = Describe("metallb", func() {
 					Spec: metallbv1alpha1.AddressPoolSpec{
 						Protocol: "layer2",
 						Addresses: []string{
-							"2.2.2.1",
-							"2.2.2.100",
+							"2.2.2.1-2.2.2.100",
 						},
 						AutoAssign: &autoAssign,
 					},
@@ -437,14 +427,12 @@ var _ = Describe("metallb", func() {
 - name: addresspool1
   protocol: layer2
   addresses:
-  - 1.1.1.1
-  - 1.1.1.100
+  - 1.1.1.1-1.1.1.100
 - name: addresspool2
   protocol: layer2
   auto-assign: false
   addresses:
-  - 2.2.2.1
-  - 2.2.2.100
+  - 2.2.2.1-2.2.2.100
 `))
 			})
 
@@ -457,8 +445,7 @@ var _ = Describe("metallb", func() {
 					Spec: metallbv1alpha1.AddressPoolSpec{
 						Protocol: "layer2",
 						Addresses: []string{
-							"1.1.1.1",
-							"1.1.1.100",
+							"1.1.1.1-1.1.1.100",
 						},
 					},
 				}
@@ -481,8 +468,7 @@ var _ = Describe("metallb", func() {
   protocol: layer2
   auto-assign: false
   addresses:
-  - 2.2.2.1
-  - 2.2.2.100
+  - 2.2.2.1-2.2.2.100
 `))
 
 			})
@@ -496,8 +482,7 @@ var _ = Describe("metallb", func() {
 					Spec: metallbv1alpha1.AddressPoolSpec{
 						Protocol: "layer2",
 						Addresses: []string{
-							"2.2.2.1",
-							"2.2.2.100",
+							"2.2.2.1-2.2.2.100",
 						},
 					},
 				}
@@ -525,8 +510,7 @@ var _ = Describe("metallb", func() {
 					Spec: metallbv1alpha1.AddressPoolSpec{
 						Protocol: "layer2",
 						Addresses: []string{
-							"1.1.1.1",
-							"1.1.1.100",
+							"1.1.1.1-1.1.1.100",
 						},
 					},
 				}
@@ -554,8 +538,7 @@ var _ = Describe("metallb", func() {
 - name: addresspool1
   protocol: layer2
   addresses:
-  - 1.1.1.1
-  - 1.1.1.100
+  - 1.1.1.1-1.1.1.100
 `))
 
 			})
@@ -574,8 +557,7 @@ var _ = Describe("metallb", func() {
 				addresspool.Spec = metallbv1alpha1.AddressPoolSpec{
 					Protocol: "layer2",
 					Addresses: []string{
-						"1.1.1.1",
-						"1.1.1.200",
+						"1.1.1.1-1.1.1.200",
 					},
 					AutoAssign: &autoAssign,
 				}
@@ -597,8 +579,7 @@ var _ = Describe("metallb", func() {
   protocol: layer2
   auto-assign: false
   addresses:
-  - 1.1.1.1
-  - 1.1.1.200
+  - 1.1.1.1-1.1.1.200
 `))
 			})
 
@@ -611,8 +592,7 @@ var _ = Describe("metallb", func() {
 					Spec: metallbv1alpha1.AddressPoolSpec{
 						Protocol: "layer2",
 						Addresses: []string{
-							"1.1.1.1",
-							"1.1.1.200",
+							"1.1.1.1-1.1.1.200",
 						},
 					},
 				}


### PR DESCRIPTION
 Add a validation webhook to avoid duplicate IP addresses in AddressPools.

In case of a duplicate IP range when applying an AddressPool, the request will be denied with an error message. 