### PR TITLE
Pin OLM install to a known working version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,7 @@ GOBIN=$(shell go env GOBIN)
 endif
 
 OPERATOR_SDK_VERSION=v1.8.1
+OLM_VERSION=v0.18.3
 
 OPM_TOOL_URL=https://api.github.com/repos/operator-framework/operator-registry/releases
 CERT_MANAGER_URL=https://github.com/jetstack/cert-manager/releases
@@ -132,7 +133,7 @@ build-bundle: ## Build the bundle image.
 	docker build -f bundle.Dockerfile -t $(BUNDLE_IMG) .
 
 deploy-olm: operator-sdk ## deploys OLM on the cluster
-	operator-sdk olm install
+	operator-sdk olm install --version $(OLM_VERSION)
 	operator-sdk olm status
 
 deploy-with-olm: ## deploys the operator with OLM instead of manifests


### PR DESCRIPTION
Currently CI installs OLM with latest version everytime,
this causes some issues unrelated to us in olm lane.
Setting the version to a known stable one solves this.

Signed-off-by: Ori Braunshtein <obraunsh@redhat.com>