### PR TITLE
Install yq with go install so it won't be part of the source code

### DIFF
--- a/hack/generate-metallb-manifests.sh
+++ b/hack/generate-metallb-manifests.sh
@@ -11,7 +11,7 @@ METALLB_SC_FILE=$(dirname "$0")/securityContext.yaml
 if ! command -v yq &> /dev/null
 then
     echo "yq binary not found, installing... "
-    GO111MODULE=on go get github.com/mikefarah/yq/v4
+    go install -mod='' github.com/mikefarah/yq/v4@v4.13.3
 fi
 
 curl ${METALLB_MANIFESTS_URL} -o _cache/${METALLB_MANIFESTS_FILE}


### PR DESCRIPTION
When installing yq with go get the go.mod file is changing and affecting
the dependencies of the main module. If one of the other modules we are
using dependes on a different version of yq there is a collision between
the yq versions.
Therefore, we should install yq without changing the dependencies.

go install builds and installs packages in module-aware mode, ignoring the
go.mod file. This is useful for installing executables without affecting the
dependencies of the main module.