### PR TITLE
Check that deployment ready replicas greater than zero

### DIFF
--- a/test/e2e/functional/tests/e2e.go
+++ b/test/e2e/functional/tests/e2e.go
@@ -83,7 +83,7 @@ var _ = Describe("metallb", func() {
 					if err != nil {
 						return false
 					}
-					return deploy.Status.ReadyReplicas == deploy.Status.Replicas
+					return deploy.Status.ReadyReplicas > 0 && deploy.Status.ReadyReplicas == deploy.Status.Replicas
 				}, metallbutils.DeployTimeout, metallbutils.Interval).Should(BeTrue())
 
 				pods, err := testclient.Client.Pods(OperatorNameSpace).List(context.Background(), metav1.ListOptions{


### PR DESCRIPTION
There is a case where both ReadyReplicas and Replicas are 0
and the Eventually passes. Adding this to avoid this situation.

Signed-off-by: Ori Braunshtein <obraunsh@redhat.com>