### PR TITLE
Fix the webhook name in webhook ca injection patch

### DIFF
--- a/config/webhook-on-openshift/webhookcainjection_patch.yaml
+++ b/config/webhook-on-openshift/webhookcainjection_patch.yaml
@@ -2,6 +2,6 @@
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
-  name: addresspoolvalidationwebhook.metallb.io
+  name: validating-webhook-configuration
   annotations:
     service.beta.openshift.io/inject-cabundle: "true"


### PR DESCRIPTION
The name was changed but the patch wasn't updated.