### PR TITLE
Add PodMonitors to deployment

### DIFF
--- a/bindata/deployment/prometheus-operator/prometheus-operator.yaml
+++ b/bindata/deployment/prometheus-operator/prometheus-operator.yaml
@@ -1,0 +1,31 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: metallb-controller
+  namespace: '{{.NameSpace}}'
+spec:
+  selector:
+    matchLabels:
+      component: controller
+  namespaceSelector:
+    matchNames:
+      - '{{.NameSpace}}'
+  podMetricsEndpoints:
+    - port: monitoring
+      path: /metrics
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: metallb-speaker
+  namespace: '{{.NameSpace}}'
+spec:
+  selector:
+    matchLabels:
+      component: speaker
+  namespaceSelector:
+    matchNames:
+      - '{{.NameSpace}}'
+  podMetricsEndpoints:
+    - port: monitoring
+      path: /metrics

--- a/bundle/manifests/metallb-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/metallb-operator.clusterserviceversion.yaml
@@ -218,6 +218,14 @@ spec:
           serviceAccountName: controller
         - rules:
             - apiGroups:
+                - apiextensions.k8s.io
+              resources:
+                - customresourcedefinitions
+              verbs:
+                - get
+                - list
+                - watch
+            - apiGroups:
                 - metallb.io
               resources:
                 - addresspools
@@ -306,6 +314,18 @@ spec:
                 - get
                 - patch
                 - update
+            - apiGroups:
+                - monitoring.coreos.com
+              resources:
+                - podmonitors
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - update
+                - watch
             - apiGroups:
                 - policy
               resources:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -7,6 +7,14 @@ metadata:
   name: manager-role
 rules:
 - apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - metallb.io
   resources:
   - addresspools
@@ -95,6 +103,18 @@ rules:
   - get
   - patch
   - update
+- apiGroups:
+  - monitoring.coreos.com
+  resources:
+  - podmonitors
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
 - apiGroups:
   - policy
   resources:

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -18,6 +18,7 @@ package controllers
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -101,6 +102,7 @@ var _ = BeforeSuite(func() {
 	Expect(err).ToNot(HaveOccurred())
 
 	ManifestPath = MetalLBManifestPathControllerTest // This is needed as the tests need to reference a directory backward
+	PodMonitorsPath = fmt.Sprintf("%s/%s", MetalLBManifestPathControllerTest, "prometheus-operator")
 
 	bgpType := os.Getenv("METALLB_BGP_TYPE")
 	err = (&MetalLBReconciler{

--- a/main.go
+++ b/main.go
@@ -22,6 +22,7 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	apiext "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
@@ -53,6 +54,7 @@ func init() {
 	utilruntime.Must(appsv1.AddToScheme(scheme))
 	utilruntime.Must(policyv1beta1.AddToScheme(scheme))
 	utilruntime.Must(rbacv1.AddToScheme(scheme))
+	utilruntime.Must(apiext.AddToScheme(scheme))
 
 	// +kubebuilder:scaffold:scheme
 }


### PR DESCRIPTION
Deploying the PodMonitors that relate to MetalLB
when a MetalLB CR is created while Prometheus
Operator is used in the cluster. This serves as a
base for scraping speaker/controller metrics.

Signed-off-by: Ori Braunshtein <obraunsh@redhat.com>