### PR TITLE
 Update FRR manifests to latest manifests from MetalLB repo 

### DIFF
--- a/bindata/deployment/frr/metallb-frr.yaml
+++ b/bindata/deployment/frr/metallb-frr.yaml
@@ -117,7 +117,7 @@ data:
     babeld=no
     sharpd=no
     pbrd=no
-    bfdd=no
+    bfdd=yes
     fabricd=no
     vrrpd=no
 
@@ -171,10 +171,13 @@ data:
   vtysh.conf: |
     service integrated-vtysh-config
   frr.conf: |+
+    ! This file gets overriden the first time the speaker renders a config.
+    ! So anything configured here is only temporary.
     frr version 7.5.1
     frr defaults traditional
     hostname Router
     line vty
+    log file /etc/frr/frr.log informational
 
 ---
 apiVersion: apps/v1
@@ -251,6 +254,20 @@ spec:
               mountPath: /var/run/frr
             - name: frr-conf
               mountPath: /etc/frr
+          # The command is FRR's default entrypoint & waiting for the log file to appear and tailing it.
+          # If the log file isn't created in 60 seconds the tail fails and the container is restarted.
+          # This workaround is needed to have the frr logs as part of kubectl logs -c frr < speaker_pod_name >.
+          command:
+            - /bin/sh
+            - -c
+            - |
+              /sbin/tini -- /usr/lib/frr/docker-start &
+              attempts=0
+              until [[ -f /etc/frr/frr.log || $attempts -eq 60 ]]; do
+                sleep 1
+                attempts=$(( $attempts + 1 ))
+              done
+              tail -f /etc/frr/frr.log
         - name: reloader
           image: '{{.FRRImage}}'
           command: ["/etc/frr_reloader/frr-reloader.sh"]

--- a/hack/generate-metallb-manifests.sh
+++ b/hack/generate-metallb-manifests.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 . $(dirname "$0")/common.sh
 
-METALLB_COMMIT_ID="de28a9447bb60a488fc0016bb3eb6e6aff2294ec" # TODO: change to commit containing FRR manifests
+METALLB_COMMIT_ID="d7afd9c94e246bc838b49a5fdee5384528513d63"
 METALLB_SC_FILE=$(dirname "$0")/securityContext.yaml
 
 NATIVE_MANIFESTS_FILE="metallb.yaml"


### PR DESCRIPTION
1. Enable BGP + BFD support. Enable an optional BFD profile that
can be associated with a BGP session. Using BFD in conjunction with
BGP allows faster failover detection.

2. Have FRR logs visible when running kubectl logs -c frr. Currently
the FRR logs aren't visible when running kubectl logs, bypassing
this by tailing the log file.