### PR TITLE
Update MetalLB speaker and controller components label

### DIFF
--- a/bindata/deployment/frr/metallb-frr.yaml
+++ b/bindata/deployment/frr/metallb-frr.yaml
@@ -185,21 +185,21 @@ kind: DaemonSet
 metadata:
   labels:
     app: metallb
-    component: speaker
+    app.kubernetes.io/component: speaker
   name: speaker
   namespace: '{{.NameSpace}}'
 spec:
   selector:
     matchLabels:
       app: metallb
-      component: speaker
+      app.kubernetes.io/component: speaker
   template:
     metadata:
       annotations:
         prometheus.io/scrape: 'true'
       labels:
         app: metallb
-        component: speaker
+        app.kubernetes.io/component: speaker
     spec:
       volumes:
         - name: frr-sockets
@@ -327,7 +327,7 @@ spec:
             #- name: METALLB_ML_BIND_PORT
             #  value: "7946"
             - name: METALLB_ML_LABELS
-              value: "app=metallb,component=speaker"
+              value: "app=metallb,app.kubernetes.io/component=speaker"
             - name: METALLB_ML_SECRET_KEY
               valueFrom:
                 secretKeyRef:
@@ -346,6 +346,24 @@ spec:
             - containerPort: 7946
               name: memberlist-udp
               protocol: UDP
+          livenessProbe:
+            httpGet:
+              path: /metrics
+              port: monitoring
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /metrics
+              port: monitoring
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:
@@ -372,7 +390,7 @@ kind: Deployment
 metadata:
   labels:
     app: metallb
-    component: controller
+    app.kubernetes.io/component: controller
   name: controller
   namespace: '{{.NameSpace}}'
 spec:
@@ -380,7 +398,7 @@ spec:
   selector:
     matchLabels:
       app: metallb
-      component: controller
+      app.kubernetes.io/component: controller
   template:
     metadata:
       annotations:
@@ -388,7 +406,7 @@ spec:
         prometheus.io/scrape: 'true'
       labels:
         app: metallb
-        component: controller
+        app.kubernetes.io/component: controller
     spec:
       containers:
         - args:
@@ -405,6 +423,24 @@ spec:
           ports:
             - containerPort: 7472
               name: monitoring
+          livenessProbe:
+            httpGet:
+              path: /metrics
+              port: monitoring
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /metrics
+              port: monitoring
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:

--- a/bindata/deployment/native/metallb.yaml
+++ b/bindata/deployment/native/metallb.yaml
@@ -84,14 +84,14 @@ kind: DaemonSet
 metadata:
   labels:
     app: metallb
-    component: speaker
+    app.kubernetes.io/component: speaker
   name: speaker
   namespace: '{{.NameSpace}}'
 spec:
   selector:
     matchLabels:
       app: metallb
-      component: speaker
+      app.kubernetes.io/component: speaker
   template:
     metadata:
       annotations:
@@ -99,7 +99,7 @@ spec:
         prometheus.io/scrape: 'true'
       labels:
         app: metallb
-        component: speaker
+        app.kubernetes.io/component: speaker
     spec:
       containers:
         - args:
@@ -125,7 +125,7 @@ spec:
             #- name: METALLB_ML_BIND_PORT
             #  value: "7946"
             - name: METALLB_ML_LABELS
-              value: "app=metallb,component=speaker"
+              value: "app=metallb,app.kubernetes.io/component=speaker"
             - name: METALLB_ML_SECRET_KEY
               valueFrom:
                 secretKeyRef:
@@ -141,6 +141,24 @@ spec:
             - containerPort: 7946
               name: memberlist-udp
               protocol: UDP
+          livenessProbe:
+            httpGet:
+              path: /metrics
+              port: monitoring
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /metrics
+              port: monitoring
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:
@@ -166,7 +184,7 @@ kind: Deployment
 metadata:
   labels:
     app: metallb
-    component: controller
+    app.kubernetes.io/component: controller
   name: controller
   namespace: '{{.NameSpace}}'
 spec:
@@ -174,7 +192,7 @@ spec:
   selector:
     matchLabels:
       app: metallb
-      component: controller
+      app.kubernetes.io/component: controller
   template:
     metadata:
       annotations:
@@ -182,7 +200,7 @@ spec:
         prometheus.io/scrape: 'true'
       labels:
         app: metallb
-        component: controller
+        app.kubernetes.io/component: controller
     spec:
       containers:
         - args:
@@ -199,6 +217,24 @@ spec:
           ports:
             - containerPort: 7472
               name: monitoring
+          livenessProbe:
+            httpGet:
+              path: /metrics
+              port: monitoring
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /metrics
+              port: monitoring
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:

--- a/hack/generate-metallb-manifests.sh
+++ b/hack/generate-metallb-manifests.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 . $(dirname "$0")/common.sh
 
-METALLB_COMMIT_ID="d7afd9c94e246bc838b49a5fdee5384528513d63"
+METALLB_COMMIT_ID="06da676fa192967190839464c58e62cae175105e"
 METALLB_SC_FILE=$(dirname "$0")/securityContext.yaml
 
 NATIVE_MANIFESTS_FILE="metallb.yaml"

--- a/test/e2e/functional/tests/e2e.go
+++ b/test/e2e/functional/tests/e2e.go
@@ -89,7 +89,7 @@ var _ = Describe("metallb", func() {
 				}, metallbutils.DeployTimeout, metallbutils.Interval).Should(BeTrue())
 
 				pods, err := testclient.Client.Pods(OperatorNameSpace).List(context.Background(), metav1.ListOptions{
-					LabelSelector: "component=controller"})
+					LabelSelector: "app.kubernetes.io/component=controller"})
 				Expect(err).ToNot(HaveOccurred())
 
 				deploy, err := testclient.Client.Deployments(metallb.Namespace).Get(context.Background(), consts.MetalLBDeploymentName, metav1.GetOptions{})
@@ -111,7 +111,7 @@ var _ = Describe("metallb", func() {
 				}, metallbutils.DeployTimeout, metallbutils.Interval).Should(BeTrue())
 
 				pods, err := testclient.Client.Pods(OperatorNameSpace).List(context.Background(), metav1.ListOptions{
-					LabelSelector: "component=speaker"})
+					LabelSelector: "app.kubernetes.io/component=speaker"})
 				Expect(err).ToNot(HaveOccurred())
 
 				daemonset, err := testclient.Client.DaemonSets(metallb.Namespace).Get(context.Background(), consts.MetalLBDaemonsetName, metav1.GetOptions{})

--- a/test/e2e/metallb/metallb.go
+++ b/test/e2e/metallb/metallb.go
@@ -51,13 +51,13 @@ func Delete(metallb *metallbv1beta1.MetalLB) {
 
 	Eventually(func() bool {
 		pods, _ := testclient.Client.Pods(metallb.Namespace).List(context.Background(), metav1.ListOptions{
-			LabelSelector: fmt.Sprintf("component=%s", consts.MetalLBDeploymentName)})
+			LabelSelector: fmt.Sprintf("app.kubernetes.io/component=%s", consts.MetalLBDeploymentName)})
 		return len(pods.Items) == 0
 	}, DeployTimeout, Interval).Should(BeTrue())
 
 	Eventually(func() bool {
 		pods, _ := testclient.Client.Pods(metallb.Namespace).List(context.Background(), metav1.ListOptions{
-			LabelSelector: fmt.Sprintf("component=%s", consts.MetalLBDaemonsetName)})
+			LabelSelector: fmt.Sprintf("app.kubernetes.io/component=%s", consts.MetalLBDaemonsetName)})
 		return len(pods.Items) == 0
 	}, DeployTimeout, Interval).Should(BeTrue())
 }


### PR DESCRIPTION
Updating the MetalLB manifests to latest, the components labels change was done in MetalLB as well.

The `app.kubernetes.io/component` label is the recommended one:
https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/