### PR TITLE
Update FRR image URL to quay.io

### DIFF
--- a/bundle/manifests/metallb-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/metallb-operator.clusterserviceversion.yaml
@@ -382,7 +382,7 @@ spec:
                       - name: METALLB_BGP_TYPE
                         value: native
                       - name: FRR_IMAGE
-                        value: frrouting/frr:v7.5.1
+                        value: quay.io/frrouting/frr:stable_7.5
                       - name: WATCH_NAMESPACE
                         valueFrom:
                           fieldRef:

--- a/config/manager/env.yaml
+++ b/config/manager/env.yaml
@@ -18,4 +18,4 @@ spec:
             - name: METALLB_BGP_TYPE
               value: "native"
             - name: FRR_IMAGE
-              value: "frrouting/frr:v7.5.1"
+              value: "quay.io/frrouting/frr:stable_7.5"


### PR DESCRIPTION
There is a rate limit in dockerhub. To avoid it we should pull the FRR image from quay.io.