### PR TITLE
Fix error on range containing a single IP

### DIFF
--- a/api/v1beta1/validate_cidrs.go
+++ b/api/v1beta1/validate_cidrs.go
@@ -51,7 +51,7 @@ func parseCIDR(cidr string) ([]*net.IPNet, error) {
 		return nil, fmt.Errorf("invalid IP range %q: invalid end IP %q", cidr, fs[1])
 	}
 
-	if bytes.Compare(start, end) >= 0 {
+	if bytes.Compare(start, end) > 0 {
 		return nil, fmt.Errorf("invalid IP range %q: start IP %q is after the end IP %q", cidr, start, end)
 	}
 


### PR DESCRIPTION
Running MetalLB's e2e tests with the Operator returns an error:
```
admission webhook "addresspoolvalidationwebhook.metallb.io" denied the request:
Failed to parse addresses for test-addresspool1:
invalid CIDR "172.18.0.6-172.18.0.6" in pool test-addresspool1:
invalid IP range "172.18.0.6-172.18.0.6":
start IP "172.18.0.6" is after the end IP "172.18.0.6"
```
This was fixed by https://github.com/metallb/metallb/pull/1011
and should be here too.

Signed-off-by: Ori Braunshtein <obraunsh@redhat.com>