### PR TITLE
Add MetalLB E2E CI lane with --use-operator

### DIFF
--- a/.github/workflows/metallb_e2e.yml
+++ b/.github/workflows/metallb_e2e.yml
@@ -1,0 +1,80 @@
+name: MetalLB-E2E
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches:
+      - main
+      - "v[0-9]+.[0-9]+.[0-9]+"
+      - "v[0-9]+.[0-9]+"
+defaults:
+  run:
+    shell: bash
+    working-directory: metallboperator
+jobs:
+  main:
+    runs-on: ubuntu-20.04
+    env:
+      built_image: "metallb-operator:ci" # Arbitrary name
+    strategy:
+      matrix:
+        go: ['1.16']
+    name: Go ${{ matrix.go }}
+    steps:
+      - name: Checkout Metal LB Operator
+        uses: actions/checkout@v2
+        with:
+          path: metallboperator
+          fetch-depth: 0 # Fetch all history for all tags and branches
+      - uses: actions/setup-go@v2
+        id: go
+        with:
+          go-version: ${{ matrix.go }}
+      - name: Verify modules
+        run: go mod verify
+      - name: Verify format
+        run: |
+          make fmt
+          git diff --exit-code
+      - name: Verify manifests
+        run: |
+          make manifests
+          git diff --exit-code
+      - name: Checkout MetalLB
+        uses: actions/checkout@v2
+        with:
+          repository: metallb/metallb
+          path: metallb
+          ref: a4b2482c334678ae79d79b5f5b3196ad760b48ac
+      - name: Install Dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install python3-pip arping ndisc6
+          sudo pip3 install -r ${GITHUB_WORKSPACE}/metallb/dev-env/requirements.txt
+      - name: Build image
+        run: |
+          docker build . -t ${built_image}
+      - name: Create multi-node K8s Kind Cluster
+        run: |
+          ./hack/kind-multi-node-cluster-without-registry.sh
+          kind load docker-image ${built_image}
+      - name: Deploy Metal LB Operator
+        run: |
+          make deploy-cert-manager
+          IMG=${built_image} KUSTOMIZE_DEPLOY_DIR="config/frr-on-ci/" ENABLE_OPERATOR_WEBHOOK="true" make deploy
+      - name: MetalLB E2E Tests
+        run: |
+          export KUBECONFIG=${HOME}/.kube/config
+          kubectl apply -f config/samples/metallb.yaml
+          cd ${GITHUB_WORKSPACE}/metallb
+          sudo -E env "PATH=$PATH" inv e2etest --skip "IPV6\|DUALSTACK" -e /tmp/kind_logs --use-operator
+      - name: Change permissions for kind logs
+        if: ${{ failure() }}
+        run: |
+          sudo chmod -R o+r /tmp/kind_logs
+      - name: Archive kind logs
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v2
+        with:
+          name: kind_logs
+          path: /tmp/kind_logs

--- a/bundle/manifests/metallb-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/metallb-operator.clusterserviceversion.yaml
@@ -170,11 +170,6 @@ metadata:
           "metadata": {
             "name": "metallb",
             "namespace": "metallb-system"
-          },
-          "spec": {
-            "nodeSelector": {
-              "feature.node.kubernetes.io/metalLB.capable": "true"
-            }
           }
         }
       ]

--- a/config/frr-on-ci/bgpTypeFRR.yaml
+++ b/config/frr-on-ci/bgpTypeFRR.yaml
@@ -1,0 +1,13 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: controller-manager
+  namespace: system
+spec:
+  template:
+    spec:
+      containers:
+        - name: manager
+          env:
+            - name: METALLB_BGP_TYPE
+              value: "frr"

--- a/config/frr-on-ci/kustomization.yaml
+++ b/config/frr-on-ci/kustomization.yaml
@@ -1,0 +1,8 @@
+
+patchesStrategicMerge:
+- bgpTypeFRR.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../kind-ci
+namespace: metallb-system

--- a/config/samples/demo/metallb.yaml
+++ b/config/samples/demo/metallb.yaml
@@ -3,3 +3,6 @@ kind: MetalLB
 metadata:
   name: metallb
   namespace: metallb-system
+spec:
+  nodeSelector:
+    feature.node.kubernetes.io/metalLB.capable: 'true'

--- a/hack/generate-metallb-manifests.sh
+++ b/hack/generate-metallb-manifests.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 . $(dirname "$0")/common.sh
 
-METALLB_COMMIT_ID="06da676fa192967190839464c58e62cae175105e"
+METALLB_COMMIT_ID="a4b2482c334678ae79d79b5f5b3196ad760b48ac"
 METALLB_SC_FILE=$(dirname "$0")/securityContext.yaml
 
 NATIVE_MANIFESTS_FILE="metallb.yaml"
@@ -68,6 +68,9 @@ yq e --inplace '. | select(.metadata.namespace == "metallb-system").metadata.nam
 # Furthermore, the sed has to be last since it breaks the yaml's syntax by adding the conditionals between
 yq e --inplace '. | select(.kind == "Deployment" and .metadata.name == "controller" and .spec.template.spec.containers[0].name == "controller").spec.template.spec.securityContext|="'"$(< ${METALLB_SC_FILE})"'"' ${FRR_MANIFESTS_DIR}/${FRR_MANIFESTS_FILE}
 sed -i 's/securityContext\: |-/securityContext\:/g' ${FRR_MANIFESTS_DIR}/${FRR_MANIFESTS_FILE} # Last because it breaks yaml syntax
+
+# Update MetalLB's E2E lane to clone the same commit as the manifests.
+yq e --inplace ".jobs.main.steps[] |= select(.name==\"Checkout MetalLB\").with.ref=\"${METALLB_COMMIT_ID}\"" .github/workflows/metallb_e2e.yml
 
 # TODO: run this script once FRR is merged
 

--- a/hack/kind-multi-node-cluster-without-registry.sh
+++ b/hack/kind-multi-node-cluster-without-registry.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -o errexit
+
+# desired cluster name; default is "kind"
+KIND_CLUSTER_NAME="${KIND_CLUSTER_NAME:-kind}"
+
+cat <<EOF | kind create cluster --image kindest/node:v1.21.1 --config=-
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+- role: control-plane
+  kubeadmConfigPatches:
+  - |
+    kind: InitConfiguration
+    nodeRegistration:
+      kubeletExtraArgs:
+        container-log-max-size: "100Mi"
+  - |
+    kind: ClusterConfiguration
+    apiServer:
+        extraArgs:
+            v: "5"
+    controllerManager:
+        extraArgs:
+            v: "5"
+    scheduler:
+        extraArgs:
+            v: "5"
+- role: worker
+  kubeadmConfigPatches:
+  - |
+    kind: InitConfiguration
+    nodeRegistration:
+      kubeletExtraArgs:
+        container-log-max-size: "100Mi"
+- role: worker
+  kubeadmConfigPatches:
+  - |
+    kind: InitConfiguration
+    nodeRegistration:
+      kubeletExtraArgs:
+        container-log-max-size: "100Mi"
+EOF


### PR DESCRIPTION
Now that metallb/metallb#1045 is in,
we can add a CI lane that runs MetalLB tests using the Operator's
Custom Resources. This enables us to test that the Operator
actually configures MetalLB properly.

Signed-off-by: Ori Braunshtein <obraunsh@redhat.com>