### PR TITLE
E2E validation tests: Extend wait for operator deployment timeout

### DIFF
--- a/test/e2e/validation/tests/validation.go
+++ b/test/e2e/validation/tests/validation.go
@@ -56,7 +56,7 @@ var _ = Describe("metallb", func() {
 					return false
 				}
 				return deploy.Status.ReadyReplicas == deploy.Status.Replicas
-			}, metallb.Timeout, metallb.Interval).Should(BeTrue())
+			}, metallb.DeployTimeout, metallb.Interval).Should(BeTrue())
 
 			pods, err := testclient.Client.Pods(OperatorNameSpace).List(context.Background(), metav1.ListOptions{
 				LabelSelector: fmt.Sprintf("control-plane=%s", consts.MetalLBOperatorDeploymentLabel)})


### PR DESCRIPTION
It can take more than 5 seconds for the operator deployment to be ready.