### PR TITLE
Add EBGPMultiHop field to BGPPeer

### DIFF
--- a/api/v1beta1/bgppeer_types.go
+++ b/api/v1beta1/bgppeer_types.go
@@ -82,6 +82,9 @@ type BGPPeerSpec struct {
 	Password string `json:"password,omitempty" yaml:"password,omitempty"`
 
 	BFDProfile string `json:"bfdProfile,omitempty" yaml:"bfdprofile,omitempty"`
+
+	// EBGP peer is multi-hops away
+	EBGPMultiHop bool `json:"ebgpMultiHop,omitempty" yaml:"ebgp-multihop,omitempty"`
 	// Add future BGP configuration here
 }
 

--- a/api/v1beta1/bgppeer_webhook_test.go
+++ b/api/v1beta1/bgppeer_webhook_test.go
@@ -145,6 +145,23 @@ func TestValidateBGPPeer(t *testing.T) {
 			},
 			expectedError: "Missing to configure HoldTime",
 		},
+		{
+			desc: "Invalid EBGPMultiHop for IBGP peer",
+			bgpPeer: &BGPPeer{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-bgppeer",
+					Namespace: MetalLBTestNameSpace,
+				},
+				Spec: BGPPeerSpec{
+					Address:      "10.0.0.2",
+					ASN:          64502,
+					MyASN:        64502,
+					RouterID:     "10.10.10.10",
+					EBGPMultiHop: true,
+				},
+			},
+			expectedError: "Invalid EBGPMultiHop parameter set for an ibgp peer",
+		},
 	}
 
 	for _, test := range tests {

--- a/bundle/manifests/metallb.io_bgppeers.yaml
+++ b/bundle/manifests/metallb.io_bgppeers.yaml
@@ -36,6 +36,9 @@ spec:
             properties:
               bfdProfile:
                 type: string
+              ebgpMultiHop:
+                description: EBGP peer is multi-hops away
+                type: boolean
               holdTime:
                 description: Requested BGP hold time, per RFC4271.
                 type: string

--- a/config/crd/bases/metallb.io_bgppeers.yaml
+++ b/config/crd/bases/metallb.io_bgppeers.yaml
@@ -38,6 +38,9 @@ spec:
             properties:
               bfdProfile:
                 type: string
+              ebgpMultiHop:
+                description: EBGP peer is multi-hops away
+                type: boolean
               holdTime:
                 description: Requested BGP hold time, per RFC4271.
                 type: string

--- a/pkg/render/metallb_config.go
+++ b/pkg/render/metallb_config.go
@@ -22,6 +22,7 @@ type peer struct {
 	NodeSelectors []nodeSelector `yaml:"node-selectors,omitempty"`
 	Password      string         `yaml:"password,omitempty"`
 	BFDProfile    string         `yaml:"bfd-profile,omitempty"`
+	EBGPMultiHop  bool           `yaml:"ebgp-multihop,omitempty"`
 }
 
 type nodeSelector struct {

--- a/pkg/render/metallb_configmap.go
+++ b/pkg/render/metallb_configmap.go
@@ -108,6 +108,7 @@ func peerToMetalLB(p metallbv1beta1.BGPPeer) peer {
 	res.Addr = p.Spec.Address
 	res.SrcAddr = p.Spec.SrcAddress
 	res.Port = p.Spec.Port
+	res.EBGPMultiHop = p.Spec.EBGPMultiHop
 	if p.Spec.HoldTime.Duration > 0 {
 		res.HoldTime = p.Spec.HoldTime.Duration.String()
 	}

--- a/pkg/render/metallb_configmap_test.go
+++ b/pkg/render/metallb_configmap_test.go
@@ -167,7 +167,8 @@ func TestRendering(t *testing.T) {
 								},
 							},
 						},
-						Password: "topsecret",
+						Password:     "topsecret",
+						EBGPMultiHop: true,
 					},
 				}, {
 					ObjectMeta: metav1.ObjectMeta{
@@ -175,10 +176,11 @@ func TestRendering(t *testing.T) {
 						Namespace: "namespace",
 					},
 					Spec: metallbv1beta1.BGPPeerSpec{
-						MyASN:      25,
-						ASN:        26,
-						Address:    "192.168.2.1",
-						SrcAddress: "192.168.2.2",
+						MyASN:        25,
+						ASN:          26,
+						Address:      "192.168.2.1",
+						SrcAddress:   "192.168.2.2",
+						EBGPMultiHop: false,
 					},
 				},
 			},

--- a/pkg/render/testdata/TestRendering/peersRendering
+++ b/pkg/render/testdata/TestRendering/peersRendering
@@ -20,6 +20,7 @@ peers:
   - match-labels:
       foo1: bar1
   password: topsecret
+  ebgp-multihop: true
 - my-asn: 25
   peer-asn: 26
   peer-address: 192.168.2.1

--- a/pkg/render/testdata/TestRendering/peersRendering.golden
+++ b/pkg/render/testdata/TestRendering/peersRendering.golden
@@ -20,6 +20,7 @@ peers:
   - match-labels:
       foo1: bar1
   password: topsecret
+  ebgp-multihop: true
 - my-asn: 25
   peer-asn: 26
   peer-address: 192.168.2.1


### PR DESCRIPTION
The Operator should support the new ebgp-multihop field
that was added by https://github.com/metallb/metallb/pull/1127.

Signed-off-by: Ori Braunshtein <obraunsh@redhat.com>