### PR TITLE
Add option to deploy kube-rbac-proxies with components 

### DIFF
--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -62,4 +62,4 @@ jobs:
     - name: Unit and Integration Tests
       run: |
         METALLB_BGP_TYPE=native make test
-        METALLB_BGP_TYPE=frr make test
+        METALLB_BGP_TYPE=frr DEPLOY_KUBE_RBAC_PROXIES=true make test

--- a/bindata/deployment/frr/metallb-frr.yaml
+++ b/bindata/deployment/frr/metallb-frr.yaml
@@ -213,6 +213,11 @@ spec:
           emptyDir: {}
         - name: metrics
           emptyDir: {}
+        {{ if .DeployKubeRbacProxies }}
+        - name: speaker-certs
+          secret:
+            secretName: speaker-certs-secret
+        {{ end }}
       initContainers:
         # Copies the initial config files with the right permissions to the shared volume.
         - name: cp-frr-files
@@ -374,6 +379,57 @@ spec:
             readOnlyRootFilesystem: true
           command:
             - /speaker
+        {{ if .DeployKubeRbacProxies }}
+        - name: kube-rbac-proxy-frr
+          image: '{{.KubeRbacProxy}}'
+          imagePullPolicy: IfNotPresent
+          args:
+            - --logtostderr
+            - --secure-listen-address=:27473
+            - --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_RSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256
+            - --upstream=http://127.0.0.1:7473/
+            - --tls-private-key-file=/etc/metrics/tls.key
+            - --tls-cert-file=/etc/metrics/tls.crt
+          ports:
+            - containerPort: 27473
+              name: https-metrics
+          resources:
+            requests:
+              cpu: 10m
+              memory: 20Mi
+          terminationMessagePolicy: FallbackToLogsOnError
+          volumeMounts:
+            - name: speaker-certs
+              mountPath: /etc/metrics
+              readOnly: true
+        - name: kube-rbac-proxy
+          image: '{{.KubeRbacProxy}}'
+          imagePullPolicy: IfNotPresent
+          args:
+            - --logtostderr
+            - --secure-listen-address=:27472
+            - --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_RSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256
+            - --upstream=http://$(METALLB_HOST):7472/
+            - --tls-private-key-file=/etc/metrics/tls.key
+            - --tls-cert-file=/etc/metrics/tls.crt
+          ports:
+            - containerPort: 27472
+              name: https-metrics
+          env:
+            - name: METALLB_HOST
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+          resources:
+            requests:
+              cpu: 10m
+              memory: 20Mi
+          terminationMessagePolicy: FallbackToLogsOnError
+          volumeMounts:
+            - name: speaker-certs
+              mountPath: /etc/metrics
+              readOnly: true
+        {{ end }}
       hostNetwork: true
       shareProcessNamespace: true
       nodeSelector:
@@ -449,6 +505,35 @@ spec:
             readOnlyRootFilesystem: true
           command:
             - /controller
+        {{ if .DeployKubeRbacProxies }}
+        - name: kube-rbac-proxy
+          image: '{{.KubeRbacProxy}}'
+          imagePullPolicy: IfNotPresent
+          args:
+            - --logtostderr
+            - --secure-listen-address=:27472
+            - --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_RSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256
+            - --upstream=http://$(METALLB_HOST):7472/
+            - --tls-private-key-file=/etc/metrics/tls.key
+            - --tls-cert-file=/etc/metrics/tls.crt
+          ports:
+            - containerPort: 27472
+              name: https-metrics
+          env:
+            - name: METALLB_HOST
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+          resources:
+            requests:
+              cpu: 10m
+              memory: 20Mi
+          terminationMessagePolicy: FallbackToLogsOnError
+          volumeMounts:
+            - name: controller-certs
+              mountPath: /etc/metrics
+              readOnly: true
+        {{ end }}
       nodeSelector:
         kubernetes.io/os: linux
       securityContext:
@@ -458,3 +543,9 @@ spec:
         {{ end }}
       serviceAccountName: controller
       terminationGracePeriodSeconds: 0
+      volumes:
+        {{ if .DeployKubeRbacProxies }}
+        - name: controller-certs
+          secret:
+            secretName: controller-certs-secret
+        {{ end }}

--- a/bundle/manifests/metallb-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/metallb-operator.clusterserviceversion.yaml
@@ -424,6 +424,12 @@ spec:
                         value: native
                       - name: FRR_IMAGE
                         value: quay.io/frrouting/frr:stable_7.5
+                      - name: KUBE_RBAC_PROXY_IMAGE
+                        value: quay.io/brancz/kube-rbac-proxy:v0.11.0
+                      - name: DEPLOY_KUBE_RBAC_PROXIES
+                        value: "false"
+                      - name: DEPLOY_PODMONITORS
+                        value: "true"
                       - name: WATCH_NAMESPACE
                         valueFrom:
                           fieldRef:
@@ -480,6 +486,18 @@ spec:
                 - deployments
               verbs:
                 - get
+            - apiGroups:
+                - authentication.k8s.io
+              resources:
+                - tokenreviews
+              verbs:
+                - create
+            - apiGroups:
+                - authorization.k8s.io
+              resources:
+                - subjectaccessreviews
+              verbs:
+                - create
           serviceAccountName: controller
         - rules:
             - apiGroups:
@@ -536,6 +554,18 @@ spec:
                 - get
                 - list
                 - watch
+            - apiGroups:
+                - authentication.k8s.io
+              resources:
+                - tokenreviews
+              verbs:
+                - create
+            - apiGroups:
+                - authorization.k8s.io
+              resources:
+                - subjectaccessreviews
+              verbs:
+                - create
             - apiGroups:
                 - ""
               resources:

--- a/config/manager/env.yaml
+++ b/config/manager/env.yaml
@@ -19,3 +19,9 @@ spec:
               value: "native"
             - name: FRR_IMAGE
               value: "quay.io/frrouting/frr:stable_7.5"
+            - name: KUBE_RBAC_PROXY_IMAGE
+              value: "quay.io/brancz/kube-rbac-proxy:v0.11.0"
+            - name: DEPLOY_KUBE_RBAC_PROXIES
+              value: "false"
+            - name: DEPLOY_PODMONITORS
+              value: "true"

--- a/config/metallb_rbac/kube_rbac_proxy.yaml
+++ b/config/metallb_rbac/kube_rbac_proxy.yaml
@@ -1,0 +1,37 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    app: metallb
+  name: kube-rbac-proxy
+  namespace: metallb-system
+rules:
+  - apiGroups:
+    - authentication.k8s.io
+    resources:
+    - tokenreviews
+    verbs:
+    - create
+  - apiGroups:
+    - authorization.k8s.io
+    resources:
+    - subjectaccessreviews
+    verbs:
+    - create
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app: metallb
+  name: kube-rbac-proxy
+  namespace: metallb-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: kube-rbac-proxy
+subjects:
+  - kind: ServiceAccount
+    name: controller
+  - kind: ServiceAccount
+    name: speaker

--- a/config/metallb_rbac/kustomization.yaml
+++ b/config/metallb_rbac/kustomization.yaml
@@ -1,6 +1,7 @@
 resources:
 - metallb.yaml
 - speaker_role_binding.yaml
+- kube_rbac_proxy.yaml
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: metallb-system

--- a/controllers/metallb_controller.go
+++ b/controllers/metallb_controller.go
@@ -154,6 +154,8 @@ func (r *MetalLBReconciler) syncMetalLBResources(config *metallbv1beta1.MetalLB)
 	data.Data["FRRImage"] = os.Getenv("FRR_IMAGE")
 	data.Data["IsOpenShift"] = r.PlatformInfo.IsOpenShift()
 	data.Data["NameSpace"] = r.Namespace
+	data.Data["KubeRbacProxy"] = os.Getenv("KUBE_RBAC_PROXY_IMAGE")
+	data.Data["DeployKubeRbacProxies"] = os.Getenv("DEPLOY_KUBE_RBAC_PROXIES") == "true"
 	objs, err := render.RenderDir(ManifestPath, &data)
 	if err != nil {
 		logger.Error(err, "Fail to render config daemon manifests")
@@ -161,7 +163,8 @@ func (r *MetalLBReconciler) syncMetalLBResources(config *metallbv1beta1.MetalLB)
 	}
 
 	// We shouldn't spam the api server trying to apply PodMonitors if the resource isn't installed.
-	if podMonitorAvailable(r.Client) {
+	deployPodMonitors := os.Getenv("DEPLOY_PODMONITORS") == "true"
+	if podMonitorAvailable(r.Client) && deployPodMonitors {
 		podmonitors, err := render.RenderDir(PodMonitorsPath, &data)
 		if err != nil {
 			logger.Error(err, "Fail to render PodMonitors manifests")

--- a/hack/kube-rbac-controller.json
+++ b/hack/kube-rbac-controller.json
@@ -1,0 +1,43 @@
+{
+  "name": "kube-rbac-proxy",
+  "image": "{{.KubeRbacProxy}}",
+  "imagePullPolicy": "IfNotPresent",
+  "args": [
+    "--logtostderr",
+    "--secure-listen-address=:27472",
+    "--tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_RSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256",
+    "--upstream=http://$(METALLB_HOST):7472/",
+    "--tls-private-key-file=/etc/metrics/tls.key",
+    "--tls-cert-file=/etc/metrics/tls.crt"
+  ],
+  "ports": [
+    {
+      "containerPort": 27472,
+      "name": "https-metrics"
+    }
+  ],
+  "env": [
+    {
+      "name": "METALLB_HOST",
+      "valueFrom": {
+        "fieldRef": {
+          "fieldPath": "status.hostIP"
+        }
+      }
+    }
+  ],
+  "resources": {
+    "requests": {
+      "cpu": "10m",
+      "memory": "20Mi"
+    }
+  },
+  "terminationMessagePolicy": "FallbackToLogsOnError",
+  "volumeMounts": [
+    {
+      "name": "controller-certs",
+      "mountPath": "/etc/metrics",
+      "readOnly": true
+    }
+  ]
+}

--- a/hack/kube-rbac-frr.json
+++ b/hack/kube-rbac-frr.json
@@ -1,0 +1,33 @@
+{
+  "name": "kube-rbac-proxy-frr",
+  "image": "{{.KubeRbacProxy}}",
+  "imagePullPolicy": "IfNotPresent",
+  "args": [
+    "--logtostderr",
+    "--secure-listen-address=:27473",
+    "--tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_RSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256",
+    "--upstream=http://127.0.0.1:7473/",
+    "--tls-private-key-file=/etc/metrics/tls.key",
+    "--tls-cert-file=/etc/metrics/tls.crt"
+  ],
+  "ports": [
+    {
+      "containerPort": 27473,
+      "name": "https-metrics"
+    }
+  ],
+  "resources": {
+    "requests": {
+      "cpu": "10m",
+      "memory": "20Mi"
+    }
+  },
+  "terminationMessagePolicy": "FallbackToLogsOnError",
+  "volumeMounts": [
+    {
+      "name": "speaker-certs",
+      "mountPath": "/etc/metrics",
+      "readOnly": true
+    }
+  ]
+}

--- a/hack/kube-rbac-speaker.json
+++ b/hack/kube-rbac-speaker.json
@@ -1,0 +1,43 @@
+{
+  "name": "kube-rbac-proxy",
+  "image": "{{.KubeRbacProxy}}",
+  "imagePullPolicy": "IfNotPresent",
+  "args": [
+    "--logtostderr",
+    "--secure-listen-address=:27472",
+    "--tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_RSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256",
+    "--upstream=http://$(METALLB_HOST):7472/",
+    "--tls-private-key-file=/etc/metrics/tls.key",
+    "--tls-cert-file=/etc/metrics/tls.crt"
+  ],
+  "ports": [
+    {
+      "containerPort": 27472,
+      "name": "https-metrics"
+    }
+  ],
+  "env": [
+    {
+      "name": "METALLB_HOST",
+      "valueFrom": {
+        "fieldRef": {
+          "fieldPath": "status.hostIP"
+        }
+      }
+    }
+  ],
+  "resources": {
+    "requests": {
+      "cpu": "10m",
+      "memory": "20Mi"
+    }
+  },
+  "terminationMessagePolicy": "FallbackToLogsOnError",
+  "volumeMounts": [
+    {
+      "name": "speaker-certs",
+      "mountPath": "/etc/metrics",
+      "readOnly": true
+    }
+  ]
+}


### PR DESCRIPTION
Some users might require the metrics endpoints to be backed
by HTTPS/RBAC (like OpenShift). Added an option to deploy
MetalLB's manifests with a sidecar kube-rbac-proxy.
Also added a toggle to disable PodMonitors deployment
if the user decides to do use a custom one.

Signed-off-by: Ori Braunshtein <obraunsh@redhat.com>