### PR TITLE
Allow only one RouterID setting in FRR BGP mode

### DIFF
--- a/api/v1beta1/bgppeer_webhook_test.go
+++ b/api/v1beta1/bgppeer_webhook_test.go
@@ -46,6 +46,22 @@ func TestValidateBGPPeer(t *testing.T) {
 			expectedError: "Invalid RouterID",
 		},
 		{
+			desc: "BGPPeer with different RouterID",
+			bgpPeer: &BGPPeer{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-bgppeer1",
+					Namespace: MetalLBTestNameSpace,
+				},
+				Spec: BGPPeerSpec{
+					Address:  "10.0.0.1",
+					ASN:      64501,
+					MyASN:    64500,
+					RouterID: "11.11.11.11",
+				},
+			},
+			expectedError: "BGPPeers with different RouterID not supported ",
+		},
+		{
 			desc: "Invalid BGP Peer IP address",
 			bgpPeer: &BGPPeer{
 				ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
We should allow only one routerid setting per BGP instance, currently
we support only one BGP instance hence we allow only one setting
for RouterID, in the future when views and vrf support is added
we can allow one routerID setting per view or per vrf.

Signed-off-by: Mohamed Mahmoud <mmahmoud@redhat.com>