### PR TITLE
AddressPool validation webhook: Add BGPAdvertisements validation 

### DIFF
--- a/api/v1beta1/addresspool_webhook.go
+++ b/api/v1beta1/addresspool_webhook.go
@@ -20,6 +20,9 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"reflect"
+	"strconv"
+	"strings"
 
 	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -88,6 +91,10 @@ func (addressPool *AddressPool) validateAddressPool(isNewAddressPool bool, exist
 		if addressPool.Spec.Protocol != "bgp" {
 			return fmt.Errorf("bgpadvertisement config not valid for protocol %s", addressPool.Spec.Protocol)
 		}
+		err := validateBGPAdvertisements(addressPool.Spec.BGPAdvertisements, addressPool.Spec.Addresses)
+		if err != nil {
+			return errors.Wrapf(err, "invalid bgpadvertisement config")
+		}
 	}
 
 	for _, existingAddressPool := range existingAddressPoolList.Items {
@@ -137,4 +144,130 @@ func getAddressPoolCIDRs(addressPool *AddressPool) ([]*net.IPNet, error) {
 		CIDRs = append(CIDRs, nets...)
 	}
 	return CIDRs, nil
+}
+
+func validateBGPAdvertisements(bgpAdvertisements []BgpAdvertisement, poolAddresses []string) error {
+	if len(bgpAdvertisements) == 0 {
+		return nil
+	}
+
+	err := validateDuplicateAdvertisements(bgpAdvertisements)
+	if err != nil {
+		return err
+	}
+
+	for _, adv := range bgpAdvertisements {
+		err := validateDuplicateCommunities(adv.Communities)
+		if err != nil {
+			return err
+		}
+
+		if adv.AggregationLength != nil {
+			err := validateAggregationLength(*adv.AggregationLength, false, poolAddresses)
+			if err != nil {
+				return err
+			}
+		}
+
+		if adv.AggregationLengthV6 != nil {
+			err := validateAggregationLength(*adv.AggregationLengthV6, true, poolAddresses)
+			if err != nil {
+				return err
+			}
+		}
+
+		for _, community := range adv.Communities {
+			fs := strings.Split(community, ":")
+			if len(fs) != 2 {
+				return fmt.Errorf("invalid community string %q", community)
+			}
+
+			_, err := strconv.ParseUint(fs[0], 10, 16)
+			if err != nil {
+				return fmt.Errorf("invalid first section of community %q: %s", fs[0], err)
+			}
+
+			_, err = strconv.ParseUint(fs[1], 10, 16)
+			if err != nil {
+				return fmt.Errorf("invalid second section of community %q: %s", fs[1], err)
+			}
+		}
+	}
+
+	return nil
+}
+
+func validateDuplicateAdvertisements(bgpAdvertisements []BgpAdvertisement) error {
+	for i := 0; i < len(bgpAdvertisements); i++ {
+		for j := i + 1; j < len(bgpAdvertisements); j++ {
+			if reflect.DeepEqual(bgpAdvertisements[i], bgpAdvertisements[j]) {
+				return errors.New("duplicate definition of bgpadvertisement")
+			}
+		}
+	}
+	return nil
+}
+
+func validateDuplicateCommunities(communities []string) error {
+	for i := 0; i < len(communities); i++ {
+		for j := i + 1; j < len(communities); j++ {
+			if strings.Compare(communities[i], communities[j]) == 0 {
+				return errors.New("duplicate definition of communities")
+			}
+		}
+	}
+	return nil
+}
+
+func validateAggregationLength(aggregationLength int32, isV6 bool, poolAddresses []string) error {
+	if isV6 {
+		if aggregationLength > 128 {
+			return fmt.Errorf("invalid aggregation length %d for IPv6", aggregationLength)
+		}
+	} else if aggregationLength > 32 {
+		return fmt.Errorf("invalid aggregation length %d for IPv4", aggregationLength)
+	}
+
+	cidrsPerAddresses := map[string][]*net.IPNet{}
+	for _, cidr := range poolAddresses {
+		nets, err := parseCIDR(cidr)
+		if err != nil {
+			return errors.Wrapf(err, "failed to parse CIDR %s to validate aggregation length %d", cidr, aggregationLength)
+		}
+		cidrsPerAddresses[cidr] = nets
+	}
+
+	for addr, cidrs := range cidrsPerAddresses {
+		if len(cidrs) == 0 {
+			continue
+		}
+
+		if isV6 && cidrs[0].IP.To4() != nil {
+			continue
+		}
+
+		// in case of range format, we may have a set of cidrs associated to a given address.
+		// We reject if none of the cidrs are compatible with the aggregation length.
+		lowest := lowestMask(cidrs)
+		if aggregationLength < int32(lowest) {
+			return fmt.Errorf("invalid aggregation length %d: prefix %d in "+
+				"this pool is more specific than the aggregation length for addresses %s", aggregationLength, lowest, addr)
+		}
+	}
+
+	return nil
+}
+
+func lowestMask(cidrs []*net.IPNet) int {
+	if len(cidrs) == 0 {
+		return 0
+	}
+	lowest, _ := cidrs[0].Mask.Size()
+	for _, c := range cidrs {
+		s, _ := c.Mask.Size()
+		if lowest > s {
+			lowest = s
+		}
+	}
+	return lowest
 }

--- a/test/e2e/functional/tests/e2e.go
+++ b/test/e2e/functional/tests/e2e.go
@@ -257,7 +257,7 @@ var _ = Describe("metallb", func() {
 					AutoAssign: &autoAssign,
 					BGPAdvertisements: []metallbv1beta1.BgpAdvertisement{
 						{
-							AggregationLength:   pointer.Int32Ptr(24),
+							AggregationLength:   pointer.Int32Ptr(32),
 							AggregationLengthV6: pointer.Int32Ptr(124),
 							LocalPref:           100,
 							Communities: []string{
@@ -277,7 +277,7 @@ var _ = Describe("metallb", func() {
   - communities: 
     - 65535:65282
     - 7003:007
-    aggregation-length: 24
+    aggregation-length: 32
     aggregation-length-v6: 124
     localpref: 100
 `),


### PR DESCRIPTION
An invalid BGPAdvertisement or duplicate BGPAdvertisement definition should be denied with an error message from
the addressPool validation webhook.