### PR TITLE
Update README for kind-ci deploy

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ export IMAGE_NAME=metallb-operator
 
 make docker-build IMG=$IMAGE_NAME
 kind load docker-image $IMAGE_NAME
+make deploy-cert-manager
 IMG=$IMAGE_NAME KUSTOMIZE_DEPLOY_DIR="config/kind-ci/" make deploy
 ```
 


### PR DESCRIPTION
The README.md doesn't have deploying cert-manager as prerequisite
step under kind-ci deployment.

Hence adding `make deploy-cert-manager` step to correct it.

Signed-off-by: Periyasamy Palanisamy <pepalani@redhat.com>