### PR TITLE
Deployment: make it possible to override the pod selector

### DIFF
--- a/bindata/deployment/frr/metallb-frr.yaml
+++ b/bindata/deployment/frr/metallb-frr.yaml
@@ -183,21 +183,21 @@ kind: DaemonSet
 metadata:
   labels:
     app: metallb
-    app.kubernetes.io/component: speaker
+    {{.SpeakerSelector}}
   name: speaker
   namespace: '{{.NameSpace}}'
 spec:
   selector:
     matchLabels:
       app: metallb
-      app.kubernetes.io/component: speaker
+      {{.SpeakerSelector}}
   template:
     metadata:
       annotations:
         prometheus.io/scrape: 'true'
       labels:
         app: metallb
-        app.kubernetes.io/component: speaker
+        {{.SpeakerSelector}}
     spec:
       volumes:
         - name: frr-sockets
@@ -330,7 +330,7 @@ spec:
             #- name: METALLB_ML_BIND_PORT
             #  value: "7946"
             - name: METALLB_ML_LABELS
-              value: "app=metallb,app.kubernetes.io/component=speaker"
+              value: "app=metallb,{{.SpeakerLabelSelector}}"
             - name: METALLB_ML_SECRET_KEY
               valueFrom:
                 secretKeyRef:
@@ -444,7 +444,7 @@ kind: Deployment
 metadata:
   labels:
     app: metallb
-    app.kubernetes.io/component: controller
+    {{.ControllerSelector}}
   name: controller
   namespace: '{{.NameSpace}}'
 spec:
@@ -452,7 +452,7 @@ spec:
   selector:
     matchLabels:
       app: metallb
-      app.kubernetes.io/component: controller
+      {{.ControllerSelector}}
   template:
     metadata:
       annotations:
@@ -460,7 +460,7 @@ spec:
         prometheus.io/scrape: 'true'
       labels:
         app: metallb
-        app.kubernetes.io/component: controller
+        {{.ControllerSelector}}
     spec:
       containers:
         - args:

--- a/bindata/deployment/native/metallb.yaml
+++ b/bindata/deployment/native/metallb.yaml
@@ -82,14 +82,14 @@ kind: DaemonSet
 metadata:
   labels:
     app: metallb
-    app.kubernetes.io/component: speaker
+    {{.SpeakerSelector}}
   name: speaker
   namespace: '{{.NameSpace}}'
 spec:
   selector:
     matchLabels:
       app: metallb
-      app.kubernetes.io/component: speaker
+      {{.SpeakerSelector}}
   template:
     metadata:
       annotations:
@@ -97,7 +97,7 @@ spec:
         prometheus.io/scrape: 'true'
       labels:
         app: metallb
-        app.kubernetes.io/component: speaker
+        {{.SpeakerSelector}}
     spec:
       containers:
         - args:
@@ -123,7 +123,7 @@ spec:
             #- name: METALLB_ML_BIND_PORT
             #  value: "7946"
             - name: METALLB_ML_LABELS
-              value: "app=metallb,app.kubernetes.io/component=speaker"
+              value: "app=metallb,{{.SpeakerLabelSelector}}"
             - name: METALLB_ML_SECRET_KEY
               valueFrom:
                 secretKeyRef:
@@ -182,7 +182,7 @@ kind: Deployment
 metadata:
   labels:
     app: metallb
-    app.kubernetes.io/component: controller
+    {{.ControllerSelector}}
   name: controller
   namespace: '{{.NameSpace}}'
 spec:
@@ -190,7 +190,7 @@ spec:
   selector:
     matchLabels:
       app: metallb
-      app.kubernetes.io/component: controller
+      {{.ControllerSelector}}
   template:
     metadata:
       annotations:
@@ -198,7 +198,7 @@ spec:
         prometheus.io/scrape: 'true'
       labels:
         app: metallb
-        app.kubernetes.io/component: controller
+        {{.ControllerSelector}}
     spec:
       containers:
         - args:

--- a/hack/generate-metallb-manifests.sh
+++ b/hack/generate-metallb-manifests.sh
@@ -94,6 +94,13 @@ sed -i 's/securityContext\: |-/securityContext\:/g' ${FRR_MANIFESTS_DIR}/${FRR_M
 sed -i "s/- name: '{{ if .DeployKubeRbacProxies }}'/{{ if .DeployKubeRbacProxies }}/g" ${FRR_MANIFESTS_DIR}/${FRR_MANIFESTS_FILE}
 sed -i "s/- name: '{{ end }}'/{{ end }}/g" ${FRR_MANIFESTS_DIR}/${FRR_MANIFESTS_FILE}
 
+sed -i "s/app.kubernetes.io\/component: speaker/{{.SpeakerSelector}}/g" ${FRR_MANIFESTS_DIR}/${FRR_MANIFESTS_FILE}
+sed -i "s/app.kubernetes.io\/component: controller/{{.ControllerSelector}}/g" ${FRR_MANIFESTS_DIR}/${FRR_MANIFESTS_FILE}
+sed -i "s/app.kubernetes.io\/component: speaker/{{.SpeakerSelector}}/g" ${NATIVE_MANIFESTS_DIR}/${NATIVE_MANIFESTS_FILE}
+sed -i "s/app.kubernetes.io\/component: controller/{{.ControllerSelector}}/g" ${NATIVE_MANIFESTS_DIR}/${NATIVE_MANIFESTS_FILE}
+sed -i "s/app.kubernetes.io\/component=speaker/{{.SpeakerLabelSelector}}/g" ${FRR_MANIFESTS_DIR}/${FRR_MANIFESTS_FILE}
+sed -i "s/app.kubernetes.io\/component=speaker/{{.SpeakerLabelSelector}}/g" ${NATIVE_MANIFESTS_DIR}/${NATIVE_MANIFESTS_FILE}
+
 # Update MetalLB's E2E lane to clone the same commit as the manifests.
 yq e --inplace ".jobs.main.steps[] |= select(.name==\"Checkout MetalLB\").with.ref=\"${METALLB_COMMIT_ID}\"" .github/workflows/metallb_e2e.yml
 

--- a/test/e2e/functional/tests/e2e.go
+++ b/test/e2e/functional/tests/e2e.go
@@ -27,17 +27,18 @@ import (
 	goclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-var autoAssign = false
-var UseMetallbResourcesFromFile = false
-
-var OperatorNameSpace = consts.DefaultOperatorNameSpace
+var (
+	autoAssign                  = false
+	UseMetallbResourcesFromFile = false
+	OperatorNameSpace           = consts.DefaultOperatorNameSpace
+)
 
 func init() {
-	if len(os.Getenv("USE_LOCAL_RESOURCES")) != 0 {
+	if _, ok := os.LookupEnv("USE_LOCAL_RESOURCES"); ok {
 		UseMetallbResourcesFromFile = true
 	}
 
-	if ns := os.Getenv("OO_INSTALL_NAMESPACE"); len(ns) != 0 {
+	if ns, ok := os.LookupEnv("OO_INSTALL_NAMESPACE"); ok {
 		OperatorNameSpace = ns
 	}
 }
@@ -88,7 +89,7 @@ var _ = Describe("metallb", func() {
 				}, metallbutils.DeployTimeout, metallbutils.Interval).Should(BeTrue())
 
 				pods, err := testclient.Client.Pods(OperatorNameSpace).List(context.Background(), metav1.ListOptions{
-					LabelSelector: "app.kubernetes.io/component=controller"})
+					LabelSelector: metallbutils.ControllerLabelSelector})
 				Expect(err).ToNot(HaveOccurred())
 
 				deploy, err := testclient.Client.Deployments(metallb.Namespace).Get(context.Background(), consts.MetalLBDeploymentName, metav1.GetOptions{})
@@ -110,7 +111,7 @@ var _ = Describe("metallb", func() {
 				}, metallbutils.DeployTimeout, metallbutils.Interval).Should(BeTrue())
 
 				pods, err := testclient.Client.Pods(OperatorNameSpace).List(context.Background(), metav1.ListOptions{
-					LabelSelector: "app.kubernetes.io/component=speaker"})
+					LabelSelector: metallbutils.SpeakerLabelSelector})
 				Expect(err).ToNot(HaveOccurred())
 
 				daemonset, err := testclient.Client.DaemonSets(metallb.Namespace).Get(context.Background(), consts.MetalLBDaemonsetName, metav1.GetOptions{})

--- a/test/e2e/metallb/metallb.go
+++ b/test/e2e/metallb/metallb.go
@@ -19,6 +19,21 @@ import (
 	goclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+var (
+	ControllerLabelSelector = "app.kubernetes.io/component=controller"
+	SpeakerLabelSelector    = "app.kubernetes.io/component=speaker"
+)
+
+func init() {
+	if v, ok := os.LookupEnv("CONTROLLER_SELECTOR"); ok {
+		ControllerLabelSelector = v
+	}
+
+	if v, ok := os.LookupEnv("SPEAKER_SELECTOR"); ok {
+		SpeakerLabelSelector = v
+	}
+}
+
 const (
 	// Timeout and Interval settings
 	Timeout       = time.Second * 5
@@ -51,13 +66,13 @@ func Delete(metallb *metallbv1beta1.MetalLB) {
 
 	Eventually(func() bool {
 		pods, _ := testclient.Client.Pods(metallb.Namespace).List(context.Background(), metav1.ListOptions{
-			LabelSelector: fmt.Sprintf("app.kubernetes.io/component=%s", consts.MetalLBDeploymentName)})
+			LabelSelector: ControllerLabelSelector})
 		return len(pods.Items) == 0
 	}, DeployTimeout, Interval).Should(BeTrue())
 
 	Eventually(func() bool {
 		pods, _ := testclient.Client.Pods(metallb.Namespace).List(context.Background(), metav1.ListOptions{
-			LabelSelector: fmt.Sprintf("app.kubernetes.io/component=%s", consts.MetalLBDaemonsetName)})
+			LabelSelector: SpeakerLabelSelector})
 		return len(pods.Items) == 0
 	}, DeployTimeout, Interval).Should(BeTrue())
 }


### PR DESCRIPTION
We moved the selector from component=speaker to app.kubernetes.io/component=controller
Since the pod selector in deploymnet/ daemonset won't work, upgrading to
the new operator will fail. Here we provide a handle to override the
selector, so existing users can upgrade smoothly.
