### PR TITLE
Revert the daemonset selector to the one used previously

### DIFF
--- a/.github/workflows/metallb_e2e.yml
+++ b/.github/workflows/metallb_e2e.yml
@@ -45,7 +45,7 @@ jobs:
         with:
           repository: metallb/metallb
           path: metallb
-          ref: b8025064d2b9413565475c7f076da1eecf7b80a0
+          ref: 46675f03d788549897ff59c6b3b268c162a394d0
       - name: Install Dependencies
         run: |
           sudo apt-get update

--- a/bindata/deployment/frr/metallb-frr.yaml
+++ b/bindata/deployment/frr/metallb-frr.yaml
@@ -183,21 +183,21 @@ kind: DaemonSet
 metadata:
   labels:
     app: metallb
-    {{.SpeakerSelector}}
+    app.kubernetes.io/component: speaker
   name: speaker
   namespace: '{{.NameSpace}}'
 spec:
   selector:
     matchLabels:
       app: metallb
-      {{.SpeakerSelector}}
+      app.kubernetes.io/component: speaker
   template:
     metadata:
       annotations:
         prometheus.io/scrape: 'true'
       labels:
         app: metallb
-        {{.SpeakerSelector}}
+        app.kubernetes.io/component: speaker
     spec:
       volumes:
         - name: frr-sockets
@@ -330,7 +330,7 @@ spec:
             #- name: METALLB_ML_BIND_PORT
             #  value: "7946"
             - name: METALLB_ML_LABELS
-              value: "app=metallb,{{.SpeakerLabelSelector}}"
+              value: "app=metallb,app.kubernetes.io/component=speaker"
             - name: METALLB_ML_SECRET_KEY
               valueFrom:
                 secretKeyRef:
@@ -444,7 +444,7 @@ kind: Deployment
 metadata:
   labels:
     app: metallb
-    {{.ControllerSelector}}
+    app.kubernetes.io/component: controller
   name: controller
   namespace: '{{.NameSpace}}'
 spec:
@@ -452,7 +452,7 @@ spec:
   selector:
     matchLabels:
       app: metallb
-      {{.ControllerSelector}}
+      app.kubernetes.io/component: controller
   template:
     metadata:
       annotations:
@@ -460,7 +460,7 @@ spec:
         prometheus.io/scrape: 'true'
       labels:
         app: metallb
-        {{.ControllerSelector}}
+        app.kubernetes.io/component: controller
     spec:
       containers:
         - args:

--- a/bindata/deployment/frr/metallb-frr.yaml
+++ b/bindata/deployment/frr/metallb-frr.yaml
@@ -183,21 +183,21 @@ kind: DaemonSet
 metadata:
   labels:
     app: metallb
-    app.kubernetes.io/component: speaker
+    component: speaker
   name: speaker
   namespace: '{{.NameSpace}}'
 spec:
   selector:
     matchLabels:
       app: metallb
-      app.kubernetes.io/component: speaker
+      component: speaker
   template:
     metadata:
       annotations:
         prometheus.io/scrape: 'true'
       labels:
         app: metallb
-        app.kubernetes.io/component: speaker
+        component: speaker
     spec:
       volumes:
         - name: frr-sockets
@@ -330,7 +330,7 @@ spec:
             #- name: METALLB_ML_BIND_PORT
             #  value: "7946"
             - name: METALLB_ML_LABELS
-              value: "app=metallb,app.kubernetes.io/component=speaker"
+              value: "app=metallb,component=speaker"
             - name: METALLB_ML_SECRET_KEY
               valueFrom:
                 secretKeyRef:
@@ -444,7 +444,7 @@ kind: Deployment
 metadata:
   labels:
     app: metallb
-    app.kubernetes.io/component: controller
+    component: controller
   name: controller
   namespace: '{{.NameSpace}}'
 spec:
@@ -452,7 +452,7 @@ spec:
   selector:
     matchLabels:
       app: metallb
-      app.kubernetes.io/component: controller
+      component: controller
   template:
     metadata:
       annotations:
@@ -460,7 +460,7 @@ spec:
         prometheus.io/scrape: 'true'
       labels:
         app: metallb
-        app.kubernetes.io/component: controller
+        component: controller
     spec:
       containers:
         - args:

--- a/bindata/deployment/native/metallb.yaml
+++ b/bindata/deployment/native/metallb.yaml
@@ -82,14 +82,14 @@ kind: DaemonSet
 metadata:
   labels:
     app: metallb
-    {{.SpeakerSelector}}
+    app.kubernetes.io/component: speaker
   name: speaker
   namespace: '{{.NameSpace}}'
 spec:
   selector:
     matchLabels:
       app: metallb
-      {{.SpeakerSelector}}
+      app.kubernetes.io/component: speaker
   template:
     metadata:
       annotations:
@@ -97,7 +97,7 @@ spec:
         prometheus.io/scrape: 'true'
       labels:
         app: metallb
-        {{.SpeakerSelector}}
+        app.kubernetes.io/component: speaker
     spec:
       containers:
         - args:
@@ -123,7 +123,7 @@ spec:
             #- name: METALLB_ML_BIND_PORT
             #  value: "7946"
             - name: METALLB_ML_LABELS
-              value: "app=metallb,{{.SpeakerLabelSelector}}"
+              value: "app=metallb,app.kubernetes.io/component=speaker"
             - name: METALLB_ML_SECRET_KEY
               valueFrom:
                 secretKeyRef:
@@ -182,7 +182,7 @@ kind: Deployment
 metadata:
   labels:
     app: metallb
-    {{.ControllerSelector}}
+    app.kubernetes.io/component: controller
   name: controller
   namespace: '{{.NameSpace}}'
 spec:
@@ -190,7 +190,7 @@ spec:
   selector:
     matchLabels:
       app: metallb
-      {{.ControllerSelector}}
+      app.kubernetes.io/component: controller
   template:
     metadata:
       annotations:
@@ -198,7 +198,7 @@ spec:
         prometheus.io/scrape: 'true'
       labels:
         app: metallb
-        {{.ControllerSelector}}
+        app.kubernetes.io/component: controller
     spec:
       containers:
         - args:

--- a/bindata/deployment/native/metallb.yaml
+++ b/bindata/deployment/native/metallb.yaml
@@ -82,14 +82,14 @@ kind: DaemonSet
 metadata:
   labels:
     app: metallb
-    app.kubernetes.io/component: speaker
+    component: speaker
   name: speaker
   namespace: '{{.NameSpace}}'
 spec:
   selector:
     matchLabels:
       app: metallb
-      app.kubernetes.io/component: speaker
+      component: speaker
   template:
     metadata:
       annotations:
@@ -97,7 +97,7 @@ spec:
         prometheus.io/scrape: 'true'
       labels:
         app: metallb
-        app.kubernetes.io/component: speaker
+        component: speaker
     spec:
       containers:
         - args:
@@ -123,7 +123,7 @@ spec:
             #- name: METALLB_ML_BIND_PORT
             #  value: "7946"
             - name: METALLB_ML_LABELS
-              value: "app=metallb,app.kubernetes.io/component=speaker"
+              value: "app=metallb,component=speaker"
             - name: METALLB_ML_SECRET_KEY
               valueFrom:
                 secretKeyRef:
@@ -182,7 +182,7 @@ kind: Deployment
 metadata:
   labels:
     app: metallb
-    app.kubernetes.io/component: controller
+    component: controller
   name: controller
   namespace: '{{.NameSpace}}'
 spec:
@@ -190,7 +190,7 @@ spec:
   selector:
     matchLabels:
       app: metallb
-      app.kubernetes.io/component: controller
+      component: controller
   template:
     metadata:
       annotations:
@@ -198,7 +198,7 @@ spec:
         prometheus.io/scrape: 'true'
       labels:
         app: metallb
-        app.kubernetes.io/component: controller
+        component: controller
     spec:
       containers:
         - args:

--- a/bindata/deployment/prometheus-operator/prometheus-operator.yaml
+++ b/bindata/deployment/prometheus-operator/prometheus-operator.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/component: controller
+      component: controller
   namespaceSelector:
     matchNames:
       - '{{.NameSpace}}'
@@ -22,7 +22,7 @@ metadata:
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/component: speaker
+      component: speaker
   namespaceSelector:
     matchNames:
       - '{{.NameSpace}}'

--- a/controllers/metallb_controller.go
+++ b/controllers/metallb_controller.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"strings"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -40,23 +39,6 @@ import (
 	apiext "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 )
-
-var (
-	controllerSelector   = "app.kubernetes.io/component: controller"
-	speakerSelector      = "app.kubernetes.io/component: speaker"
-	speakerLabelSelector = "app.kubernetes.io/component=speaker"
-)
-
-func init() {
-	if v, ok := os.LookupEnv("CONTROLLER_SELECTOR"); ok {
-		controllerSelector = v
-	}
-
-	if v, ok := os.LookupEnv("SPEAKER_SELECTOR"); ok {
-		speakerSelector = v
-		speakerLabelSelector = strings.Replace(speakerSelector, ": ", "=", -1)
-	}
-}
 
 const (
 	defaultMetalLBCrName          = "metallb"
@@ -174,11 +156,6 @@ func (r *MetalLBReconciler) syncMetalLBResources(config *metallbv1beta1.MetalLB)
 	data.Data["NameSpace"] = r.Namespace
 	data.Data["KubeRbacProxy"] = os.Getenv("KUBE_RBAC_PROXY_IMAGE")
 	data.Data["DeployKubeRbacProxies"] = os.Getenv("DEPLOY_KUBE_RBAC_PROXIES") == "true"
-
-	data.Data["ControllerSelector"] = controllerSelector
-	data.Data["SpeakerSelector"] = speakerSelector
-	data.Data["SpeakerLabelSelector"] = speakerLabelSelector
-
 	objs, err := render.RenderDir(ManifestPath, &data)
 	if err != nil {
 		logger.Error(err, "Fail to render config daemon manifests")

--- a/hack/generate-metallb-manifests.sh
+++ b/hack/generate-metallb-manifests.sh
@@ -94,13 +94,6 @@ sed -i 's/securityContext\: |-/securityContext\:/g' ${FRR_MANIFESTS_DIR}/${FRR_M
 sed -i "s/- name: '{{ if .DeployKubeRbacProxies }}'/{{ if .DeployKubeRbacProxies }}/g" ${FRR_MANIFESTS_DIR}/${FRR_MANIFESTS_FILE}
 sed -i "s/- name: '{{ end }}'/{{ end }}/g" ${FRR_MANIFESTS_DIR}/${FRR_MANIFESTS_FILE}
 
-sed -i "s/app.kubernetes.io\/component: speaker/{{.SpeakerSelector}}/g" ${FRR_MANIFESTS_DIR}/${FRR_MANIFESTS_FILE}
-sed -i "s/app.kubernetes.io\/component: controller/{{.ControllerSelector}}/g" ${FRR_MANIFESTS_DIR}/${FRR_MANIFESTS_FILE}
-sed -i "s/app.kubernetes.io\/component: speaker/{{.SpeakerSelector}}/g" ${NATIVE_MANIFESTS_DIR}/${NATIVE_MANIFESTS_FILE}
-sed -i "s/app.kubernetes.io\/component: controller/{{.ControllerSelector}}/g" ${NATIVE_MANIFESTS_DIR}/${NATIVE_MANIFESTS_FILE}
-sed -i "s/app.kubernetes.io\/component=speaker/{{.SpeakerLabelSelector}}/g" ${FRR_MANIFESTS_DIR}/${FRR_MANIFESTS_FILE}
-sed -i "s/app.kubernetes.io\/component=speaker/{{.SpeakerLabelSelector}}/g" ${NATIVE_MANIFESTS_DIR}/${NATIVE_MANIFESTS_FILE}
-
 # Update MetalLB's E2E lane to clone the same commit as the manifests.
 yq e --inplace ".jobs.main.steps[] |= select(.name==\"Checkout MetalLB\").with.ref=\"${METALLB_COMMIT_ID}\"" .github/workflows/metallb_e2e.yml
 

--- a/hack/generate-metallb-manifests.sh
+++ b/hack/generate-metallb-manifests.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 . $(dirname "$0")/common.sh
 
-METALLB_COMMIT_ID="b8025064d2b9413565475c7f076da1eecf7b80a0"
+METALLB_COMMIT_ID="46675f03d788549897ff59c6b3b268c162a394d0"
 METALLB_SC_FILE=$(dirname "$0")/securityContext.yaml
 
 NATIVE_MANIFESTS_FILE="metallb.yaml"

--- a/test/e2e/functional/tests/e2e.go
+++ b/test/e2e/functional/tests/e2e.go
@@ -88,7 +88,7 @@ var _ = Describe("metallb", func() {
 				}, metallbutils.DeployTimeout, metallbutils.Interval).Should(BeTrue())
 
 				pods, err := testclient.Client.Pods(OperatorNameSpace).List(context.Background(), metav1.ListOptions{
-					LabelSelector: "app.kubernetes.io/component=controller"})
+					LabelSelector: "component=controller"})
 				Expect(err).ToNot(HaveOccurred())
 
 				deploy, err := testclient.Client.Deployments(metallb.Namespace).Get(context.Background(), consts.MetalLBDeploymentName, metav1.GetOptions{})
@@ -110,7 +110,7 @@ var _ = Describe("metallb", func() {
 				}, metallbutils.DeployTimeout, metallbutils.Interval).Should(BeTrue())
 
 				pods, err := testclient.Client.Pods(OperatorNameSpace).List(context.Background(), metav1.ListOptions{
-					LabelSelector: "app.kubernetes.io/component=speaker"})
+					LabelSelector: "component=speaker"})
 				Expect(err).ToNot(HaveOccurred())
 
 				daemonset, err := testclient.Client.DaemonSets(metallb.Namespace).Get(context.Background(), consts.MetalLBDaemonsetName, metav1.GetOptions{})

--- a/test/e2e/functional/tests/e2e.go
+++ b/test/e2e/functional/tests/e2e.go
@@ -27,18 +27,17 @@ import (
 	goclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-var (
-	autoAssign                  = false
-	UseMetallbResourcesFromFile = false
-	OperatorNameSpace           = consts.DefaultOperatorNameSpace
-)
+var autoAssign = false
+var UseMetallbResourcesFromFile = false
+
+var OperatorNameSpace = consts.DefaultOperatorNameSpace
 
 func init() {
-	if _, ok := os.LookupEnv("USE_LOCAL_RESOURCES"); ok {
+	if len(os.Getenv("USE_LOCAL_RESOURCES")) != 0 {
 		UseMetallbResourcesFromFile = true
 	}
 
-	if ns, ok := os.LookupEnv("OO_INSTALL_NAMESPACE"); ok {
+	if ns := os.Getenv("OO_INSTALL_NAMESPACE"); len(ns) != 0 {
 		OperatorNameSpace = ns
 	}
 }
@@ -89,7 +88,7 @@ var _ = Describe("metallb", func() {
 				}, metallbutils.DeployTimeout, metallbutils.Interval).Should(BeTrue())
 
 				pods, err := testclient.Client.Pods(OperatorNameSpace).List(context.Background(), metav1.ListOptions{
-					LabelSelector: metallbutils.ControllerLabelSelector})
+					LabelSelector: "app.kubernetes.io/component=controller"})
 				Expect(err).ToNot(HaveOccurred())
 
 				deploy, err := testclient.Client.Deployments(metallb.Namespace).Get(context.Background(), consts.MetalLBDeploymentName, metav1.GetOptions{})
@@ -111,7 +110,7 @@ var _ = Describe("metallb", func() {
 				}, metallbutils.DeployTimeout, metallbutils.Interval).Should(BeTrue())
 
 				pods, err := testclient.Client.Pods(OperatorNameSpace).List(context.Background(), metav1.ListOptions{
-					LabelSelector: metallbutils.SpeakerLabelSelector})
+					LabelSelector: "app.kubernetes.io/component=speaker"})
 				Expect(err).ToNot(HaveOccurred())
 
 				daemonset, err := testclient.Client.DaemonSets(metallb.Namespace).Get(context.Background(), consts.MetalLBDaemonsetName, metav1.GetOptions{})

--- a/test/e2e/metallb/metallb.go
+++ b/test/e2e/metallb/metallb.go
@@ -19,21 +19,6 @@ import (
 	goclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-var (
-	ControllerLabelSelector = "app.kubernetes.io/component=controller"
-	SpeakerLabelSelector    = "app.kubernetes.io/component=speaker"
-)
-
-func init() {
-	if v, ok := os.LookupEnv("CONTROLLER_SELECTOR"); ok {
-		ControllerLabelSelector = v
-	}
-
-	if v, ok := os.LookupEnv("SPEAKER_SELECTOR"); ok {
-		SpeakerLabelSelector = v
-	}
-}
-
 const (
 	// Timeout and Interval settings
 	Timeout       = time.Second * 5
@@ -66,13 +51,13 @@ func Delete(metallb *metallbv1beta1.MetalLB) {
 
 	Eventually(func() bool {
 		pods, _ := testclient.Client.Pods(metallb.Namespace).List(context.Background(), metav1.ListOptions{
-			LabelSelector: ControllerLabelSelector})
+			LabelSelector: fmt.Sprintf("app.kubernetes.io/component=%s", consts.MetalLBDeploymentName)})
 		return len(pods.Items) == 0
 	}, DeployTimeout, Interval).Should(BeTrue())
 
 	Eventually(func() bool {
 		pods, _ := testclient.Client.Pods(metallb.Namespace).List(context.Background(), metav1.ListOptions{
-			LabelSelector: SpeakerLabelSelector})
+			LabelSelector: fmt.Sprintf("app.kubernetes.io/component=%s", consts.MetalLBDaemonsetName)})
 		return len(pods.Items) == 0
 	}, DeployTimeout, Interval).Should(BeTrue())
 }

--- a/test/e2e/metallb/metallb.go
+++ b/test/e2e/metallb/metallb.go
@@ -51,13 +51,13 @@ func Delete(metallb *metallbv1beta1.MetalLB) {
 
 	Eventually(func() bool {
 		pods, _ := testclient.Client.Pods(metallb.Namespace).List(context.Background(), metav1.ListOptions{
-			LabelSelector: fmt.Sprintf("app.kubernetes.io/component=%s", consts.MetalLBDeploymentName)})
+			LabelSelector: fmt.Sprintf("component=%s", consts.MetalLBDeploymentName)})
 		return len(pods.Items) == 0
 	}, DeployTimeout, Interval).Should(BeTrue())
 
 	Eventually(func() bool {
 		pods, _ := testclient.Client.Pods(metallb.Namespace).List(context.Background(), metav1.ListOptions{
-			LabelSelector: fmt.Sprintf("app.kubernetes.io/component=%s", consts.MetalLBDaemonsetName)})
+			LabelSelector: fmt.Sprintf("component=%s", consts.MetalLBDaemonsetName)})
 		return len(pods.Items) == 0
 	}, DeployTimeout, Interval).Should(BeTrue())
 }


### PR DESCRIPTION
Changing the label selector will break upgrades, because it's not possible to change the selector in daemonsets, effectively not rolling up the new metallb.

Here we roll back before releasing a new metallb-operator version.