### PR TITLE
Add undeploy target option

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,6 +98,9 @@ deploy: manifests kustomize configure-operator-webhook ## Deploy controller in t
 	$(KUSTOMIZE) build $(KUSTOMIZE_DEPLOY_DIR) | kubectl apply -f -
 	$(KUSTOMIZE) build config/metallb_rbac | kubectl apply -f -
 
+undeploy: ## Remove the controller in the configured cluster
+	cd $(KUSTOMIZE_DEPLOY_DIR) && $(KUSTOMIZE) build . | kubectl delete -f -
+
 BIN_FILE ?= "metallb-operator.yaml"
 bin: manifests kustomize configure-operator-webhook ## Create manifests
 	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}


### PR DESCRIPTION
This adds undeploy Makefile target option which removes metallb
controller from the cluster which is previously installed with
deploy command.

Signed-off-by: Periyasamy Palanisamy <pepalani@redhat.com>