### PR TITLE
Add call to helper function in Unit Tests

### DIFF
--- a/controllers/addresspool_controller_test.go
+++ b/controllers/addresspool_controller_test.go
@@ -2,24 +2,19 @@ package controllers
 
 import (
 	"context"
-	"time"
 
 	"k8s.io/utils/pointer"
 
 	"github.com/metallb/metallb-operator/api/v1beta1"
 	metallbv1beta1 "github.com/metallb/metallb-operator/api/v1beta1"
-	"github.com/metallb/metallb-operator/pkg/apply"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 )
 
 var _ = Describe("AddressPool Controller", func() {
 	Context("Creating AddressPool object Layer2 Config", func() {
 		autoAssign := false
-		configmap := &corev1.ConfigMap{}
 
 		BeforeEach(func() {
 			metallb := &metallbv1beta1.MetalLB{
@@ -69,31 +64,19 @@ var _ = Describe("AddressPool Controller", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Checking ConfigMap is created and matches test-addresspool1 configuration")
-			Eventually(func() (string, error) {
-				err := k8sClient.Get(context.Background(), types.NamespacedName{Name: apply.MetalLBConfigMap, Namespace: MetalLBTestNameSpace}, configmap)
-				if err != nil {
-					return "", err
-				}
-				return configmap.Data[apply.MetalLBConfigMap], err
-			}, 2*time.Second, 200*time.Millisecond).Should(MatchYAML(`address-pools:
+			validateConfigMatchesYaml(`address-pools:
 - name: test-addresspool1
   protocol: layer2
   auto-assign: false
   addresses:
   - 1.1.1.1-1.1.1.100
-`))
+`)
 			By("Creating 2nd AddressPool resource")
 			err = k8sClient.Create(context.Background(), addressPool2)
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Checking ConfigMap is created and matches test-addresspool1 & 2 configuration")
-			Eventually(func() (string, error) {
-				err := k8sClient.Get(context.Background(), types.NamespacedName{Name: apply.MetalLBConfigMap, Namespace: MetalLBTestNameSpace}, configmap)
-				if err != nil {
-					return "", err
-				}
-				return configmap.Data[apply.MetalLBConfigMap], err
-			}, 2*time.Second, 200*time.Millisecond).Should(MatchYAML(`address-pools:
+			validateConfigMatchesYaml(`address-pools:
 - name: test-addresspool1
   protocol: layer2
   auto-assign: false
@@ -104,42 +87,31 @@ var _ = Describe("AddressPool Controller", func() {
   auto-assign: false
   addresses:
   - 2.2.2.2-2.2.2.100
-`))
+`)
 			By("Deleting 1st AddressPool resource")
 			err = k8sClient.Delete(context.Background(), addressPool1)
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Checking ConfigMap is created and matches test-addresspool2 configuration")
-			Eventually(func() (string, error) {
-				err := k8sClient.Get(context.Background(), types.NamespacedName{Name: apply.MetalLBConfigMap, Namespace: MetalLBTestNameSpace}, configmap)
-				if err != nil {
-					return "", err
-				}
-				return configmap.Data[apply.MetalLBConfigMap], err
-			}, 2*time.Second, 200*time.Millisecond).Should(MatchYAML(`address-pools:
+			validateConfigMatchesYaml(`address-pools:
 - name: test-addresspool2
   protocol: layer2
   auto-assign: false
   addresses:
   - 2.2.2.2-2.2.2.100
 
-`))
+`)
 			By("Deleting 2nd AddressPool resource")
 			err = k8sClient.Delete(context.Background(), addressPool2)
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Checking ConfigMap is empty")
-			Eventually(func() string {
-				err := k8sClient.Get(context.Background(), types.NamespacedName{Name: apply.MetalLBConfigMap, Namespace: MetalLBTestNameSpace}, configmap)
-				Expect(err).ToNot(HaveOccurred())
-				return configmap.Data["config"]
-			}, 2*time.Second, 200*time.Millisecond).Should(MatchYAML("{}"))
+			validateConfigMatchesYaml("{}")
 		})
 	})
 
 	Context("Creating AddressPool object BGP Config", func() {
 		autoAssign := false
-		configmap := &corev1.ConfigMap{}
 		addressPool := &v1beta1.AddressPool{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "test-addresspool-bgp",
@@ -190,13 +162,7 @@ var _ = Describe("AddressPool Controller", func() {
 
 			// Checking ConfigMap is created
 			By("Checking ConfigMap is created and matches test-addresspool-bgp configuration")
-			Eventually(func() (string, error) {
-				err := k8sClient.Get(context.Background(), types.NamespacedName{Name: apply.MetalLBConfigMap, Namespace: MetalLBTestNameSpace}, configmap)
-				if err != nil {
-					return "", err
-				}
-				return configmap.Data[apply.MetalLBConfigMap], err
-			}, 2*time.Second, 200*time.Millisecond).Should(MatchYAML(`address-pools:
+			validateConfigMatchesYaml(`address-pools:
 - name: test-addresspool-bgp
   protocol: bgp
   auto-assign: false
@@ -210,7 +176,7 @@ var _ = Describe("AddressPool Controller", func() {
     aggregation-length: 24
     aggregation-length-v6: 124
     localpref: 100
-`))
+`)
 		})
 	})
 })

--- a/controllers/bfdprofile_controller_test.go
+++ b/controllers/bfdprofile_controller_test.go
@@ -2,17 +2,12 @@ package controllers
 
 import (
 	"context"
-	"time"
 
 	"github.com/metallb/metallb-operator/api/v1beta1"
 	metallbv1beta1 "github.com/metallb/metallb-operator/api/v1beta1"
-	"github.com/metallb/metallb-operator/pkg/apply"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/pointer"
 )
 
@@ -581,19 +576,4 @@ bfd-profiles:
 
 func uint32Ptr(n uint32) *uint32 {
 	return &n
-}
-
-func validateConfigMatchesYaml(toMatch string) {
-	configmap := &corev1.ConfigMap{}
-	EventuallyWithOffset(1, func() (string, error) {
-		err := k8sClient.Get(context.Background(),
-			types.NamespacedName{Name: apply.MetalLBConfigMap, Namespace: MetalLBTestNameSpace}, configmap)
-		if err != nil {
-			if errors.IsNotFound(err) {
-				return "", nil
-			}
-			return "", err
-		}
-		return configmap.Data[apply.MetalLBConfigMap], err
-	}, 2*time.Second, 200*time.Millisecond).Should(MatchYAML(toMatch))
 }

--- a/controllers/bgppeer_controller_test.go
+++ b/controllers/bgppeer_controller_test.go
@@ -2,24 +2,18 @@ package controllers
 
 import (
 	"context"
-	"time"
 
 	"k8s.io/utils/pointer"
 
 	"github.com/metallb/metallb-operator/api/v1beta1"
 	metallbv1beta1 "github.com/metallb/metallb-operator/api/v1beta1"
-	"github.com/metallb/metallb-operator/pkg/apply"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 )
 
 var _ = Describe("Peer Controller", func() {
 	Context("Creating Peer object", func() {
-		configmap := &corev1.ConfigMap{}
 		BeforeEach(func() {
 			metallb := &metallbv1beta1.MetalLB{
 				ObjectMeta: metav1.ObjectMeta{
@@ -80,14 +74,7 @@ var _ = Describe("Peer Controller", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Checking ConfigMap is created and matches bgp-peer1 configuration")
-			Eventually(func() (string, error) {
-				err := k8sClient.Get(context.Background(),
-					types.NamespacedName{Name: apply.MetalLBConfigMap, Namespace: MetalLBTestNameSpace}, configmap)
-				if err != nil {
-					return "", err
-				}
-				return configmap.Data[apply.MetalLBConfigMap], err
-			}, 2*time.Second, 200*time.Millisecond).Should(MatchYAML(`peers:
+			validateConfigMatchesYaml(`peers:
 - my-asn: 64500
   node-selectors:
   - match-expressions:
@@ -99,20 +86,13 @@ var _ = Describe("Peer Controller", func() {
   peer-address: 10.0.0.1
   peer-asn: 64501
   router-id: 10.10.10.10
-`))
+`)
 			By("Creating 2nd BGPPeer resource")
 			err = k8sClient.Create(context.Background(), Peer2)
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Checking ConfigMap is created and matches bgp-peer1 & 2 configuration")
-			Eventually(func() (string, error) {
-				err := k8sClient.Get(context.Background(),
-					types.NamespacedName{Name: apply.MetalLBConfigMap, Namespace: MetalLBTestNameSpace}, configmap)
-				if err != nil {
-					return "", err
-				}
-				return configmap.Data[apply.MetalLBConfigMap], err
-			}, 2*time.Second, 200*time.Millisecond).Should(MatchYAML(`peers:
+			validateConfigMatchesYaml(`peers:
 - my-asn: 64500
   node-selectors:
   - match-expressions:
@@ -128,49 +108,29 @@ var _ = Describe("Peer Controller", func() {
   peer-address: 11.0.0.1
   peer-asn: 64001
   router-id: 11.11.11.11
-`))
+`)
 
 			By("Deleting 1st BGPPeer resource")
 			err = k8sClient.Delete(context.Background(), Peer1)
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Checking ConfigMap matches bgp-peer2 configuration")
-			Eventually(func() string {
-				err := k8sClient.Get(context.Background(),
-					types.NamespacedName{Name: apply.MetalLBConfigMap, Namespace: MetalLBTestNameSpace}, configmap)
-				if err != nil {
-					return ""
-				}
-				res := configmap.Data[apply.MetalLBConfigMap]
-				return res
-			}, 2*time.Second, 200*time.Millisecond).Should(MatchYAML(`peers:
+			validateConfigMatchesYaml(`peers:
 - my-asn: 64000
   peer-address: 11.0.0.1
   peer-asn: 64001
   router-id: 11.11.11.11
-`))
+`)
 			By("Deleting 2nd BGPPeer resource")
 			err = k8sClient.Delete(context.Background(), Peer2)
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Checking the ConfigMap is cleared")
-			Eventually(func() (string, error) {
-				err := k8sClient.Get(context.Background(),
-					types.NamespacedName{Name: apply.MetalLBConfigMap, Namespace: MetalLBTestNameSpace}, configmap)
-				if err != nil {
-					// if its notfound means that was the last object and configmap is deleted
-					if errors.IsNotFound(err) {
-						return "", nil
-					}
-					return "", err
-				}
-				return configmap.Data[apply.MetalLBConfigMap], err
-			}, 2*time.Second, 200*time.Millisecond).Should(MatchYAML("{}"))
+			validateConfigMatchesYaml("{}")
 		})
 	})
 
 	Context("Creating Full BGP configuration", func() {
-		configmap := &corev1.ConfigMap{}
 		BeforeEach(func() {
 			metallb := &metallbv1beta1.MetalLB{
 				ObjectMeta: metav1.ObjectMeta{
@@ -255,13 +215,7 @@ var _ = Describe("Peer Controller", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Checking ConfigMap is created and matches test-addresspool1 configuration")
-			Eventually(func() (string, error) {
-				err := k8sClient.Get(context.Background(), types.NamespacedName{Name: apply.MetalLBConfigMap, Namespace: MetalLBTestNameSpace}, configmap)
-				if err != nil {
-					return "", err
-				}
-				return configmap.Data[apply.MetalLBConfigMap], err
-			}, 2*time.Second, 200*time.Millisecond).Should(MatchYAML(`address-pools:
+			validateConfigMatchesYaml(`address-pools:
 - name: test-addresspool1
   protocol: bgp
   addresses:
@@ -274,20 +228,13 @@ var _ = Describe("Peer Controller", func() {
     aggregation-length: 24
     aggregation-length-v6: 128
     localpref: 100
-`))
+`)
 			By("Creating 1st BGPPeer resource")
 			err = k8sClient.Create(context.Background(), Peer1)
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Checking ConfigMap is created and matches test-addresspool1 and bgp-peer1 configuration")
-			Eventually(func() (string, error) {
-				err := k8sClient.Get(context.Background(),
-					types.NamespacedName{Name: apply.MetalLBConfigMap, Namespace: MetalLBTestNameSpace}, configmap)
-				if err != nil {
-					return "", err
-				}
-				return configmap.Data[apply.MetalLBConfigMap], err
-			}, 2*time.Second, 200*time.Millisecond).Should(MatchYAML(`address-pools:
+			validateConfigMatchesYaml(`address-pools:
 - name: test-addresspool1
   protocol: bgp
   addresses:
@@ -305,19 +252,13 @@ peers:
   peer-address: 10.0.0.1
   peer-asn: 64501
   router-id: 10.10.10.10
-`))
+`)
 			By("Creating 2nd AddressPool resource")
 			err = k8sClient.Create(context.Background(), addressPool2)
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Checking ConfigMap is created and matches test-addresspool1,2 and bgp-peer1 configuration")
-			Eventually(func() (string, error) {
-				err := k8sClient.Get(context.Background(), types.NamespacedName{Name: apply.MetalLBConfigMap, Namespace: MetalLBTestNameSpace}, configmap)
-				if err != nil {
-					return "", err
-				}
-				return configmap.Data[apply.MetalLBConfigMap], err
-			}, 2*time.Second, 200*time.Millisecond).Should(MatchYAML(`address-pools:
+			validateConfigMatchesYaml(`address-pools:
 - name: test-addresspool1
   protocol: bgp
   addresses:
@@ -340,19 +281,12 @@ peers:
   peer-address: 10.0.0.1
   peer-asn: 64501
   router-id: 10.10.10.10
-`))
+`)
 			By("Creating 2nd BGPPeer resource")
 			err = k8sClient.Create(context.Background(), Peer2)
 			Expect(err).ToNot(HaveOccurred())
 			By("Checking ConfigMap is created and matches test-addresspool1,2 and bgp-peer1,2 configuration")
-			Eventually(func() (string, error) {
-				err := k8sClient.Get(context.Background(),
-					types.NamespacedName{Name: apply.MetalLBConfigMap, Namespace: MetalLBTestNameSpace}, configmap)
-				if err != nil {
-					return "", err
-				}
-				return configmap.Data[apply.MetalLBConfigMap], err
-			}, 2*time.Second, 200*time.Millisecond).Should(MatchYAML(`address-pools:
+			validateConfigMatchesYaml(`address-pools:
 - name: test-addresspool1
   protocol: bgp
   addresses:
@@ -379,20 +313,13 @@ peers:
   peer-address: 11.0.0.1
   peer-asn: 64001
   router-id: 11.11.11.11
-`))
+`)
 			By("Deleting 1st BGPPeer resource")
 			err = k8sClient.Delete(context.Background(), Peer1)
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Checking ConfigMap matches configuration")
-			Eventually(func() (string, error) {
-				err := k8sClient.Get(context.Background(),
-					types.NamespacedName{Name: apply.MetalLBConfigMap, Namespace: MetalLBTestNameSpace}, configmap)
-				if err != nil {
-					return "", err
-				}
-				return configmap.Data[apply.MetalLBConfigMap], err
-			}, 2*time.Second, 200*time.Millisecond).Should(MatchYAML(`address-pools:
+			validateConfigMatchesYaml(`address-pools:
 - name: test-addresspool1
   protocol: bgp
   addresses:
@@ -415,19 +342,13 @@ peers:
   peer-address: 11.0.0.1
   peer-asn: 64001
   router-id: 11.11.11.11
-`))
+`)
 			By("Deleting 1st AddressPool resource")
 			err = k8sClient.Delete(context.Background(), addressPool1)
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Checking ConfigMap is created and matches test-addresspool2 and bgp-peer2 configuration")
-			Eventually(func() (string, error) {
-				err := k8sClient.Get(context.Background(), types.NamespacedName{Name: apply.MetalLBConfigMap, Namespace: MetalLBTestNameSpace}, configmap)
-				if err != nil {
-					return "", err
-				}
-				return configmap.Data[apply.MetalLBConfigMap], err
-			}, 2*time.Second, 200*time.Millisecond).Should(MatchYAML(`address-pools:
+			validateConfigMatchesYaml(`address-pools:
 - name: test-addresspool2
   protocol: bgp
   addresses:
@@ -438,39 +359,25 @@ peers:
   peer-address: 11.0.0.1
   peer-asn: 64001
   router-id: 11.11.11.11
-`))
+`)
 			By("Deleting 2nd BGPPeer resource")
 			err = k8sClient.Delete(context.Background(), Peer2)
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Checking all peers configuration is deleted and test-addresspool2 is still there")
-			Eventually(func() (string, error) {
-				err := k8sClient.Get(context.Background(),
-					types.NamespacedName{Name: apply.MetalLBConfigMap, Namespace: MetalLBTestNameSpace}, configmap)
-				if err != nil {
-					if errors.IsNotFound(err) {
-						return "", nil
-					}
-					return "", err
-				}
-				return configmap.Data[apply.MetalLBConfigMap], err
-			}, 2*time.Second, 200*time.Millisecond).Should(MatchYAML(`address-pools:
+			validateConfigMatchesYaml(`address-pools:
 - name: test-addresspool2
   protocol: bgp
   addresses:
   - 2.2.2.2-2.2.2.100
   auto-assign: false
-`))
+`)
 			By("Deleting 2nd AddressPool resource")
 			err = k8sClient.Delete(context.Background(), addressPool2)
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Checking ConfigMap is cleared")
-			Eventually(func() string {
-				err := k8sClient.Get(context.Background(), types.NamespacedName{Name: apply.MetalLBConfigMap, Namespace: MetalLBTestNameSpace}, configmap)
-				Expect(err).ToNot(HaveOccurred())
-				return configmap.Data[apply.MetalLBConfigMap]
-			}, 2*time.Second, 200*time.Millisecond).Should(MatchYAML("{}"))
+			validateConfigMatchesYaml("{}")
 		})
 	})
 })


### PR DESCRIPTION
On bfdprofile_controller_test.go there is helper function
called validateConfigMatchesYaml which is being used in this file.

This commit change the files:
controllers/addresspool_controller_test.go
controllers/bgppeer_controller_test.go
And make them use this helper function as well.