### PR TITLE
WIP: Config: Add ServiceMonitors permissions

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -97,6 +97,7 @@ rules:
   - monitoring.coreos.com
   resources:
   - podmonitors
+  - servicemonitors
   verbs:
   - create
   - delete
@@ -105,6 +106,18 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
 - apiGroups:
   - policy
   resources:


### PR DESCRIPTION
OpenShift requires enabling ServiceMonitors for metrics to be scraped via https. This commit adds permissions
for ServiceMonitors.

This is done to fix the following error that occurs when deploying the operator through manifests on OpenShift:
```
2022-02-07T15:44:21.092Z	ERROR	controller-runtime.manager.controller.metallb	Reconciler error	{"reconciler group": "metallb.io", "reconciler kind": "MetalLB", "name": "metallb", "namespace": "metallb-system", "error": "FailedToSyncMetalLBResources: could not apply (monitoring.coreos.com/v1, Kind=ServiceMonitor) metallb-system/monitor-metallb-speaker: could not update object (monitoring.coreos.com/v1, Kind=ServiceMonitor) metallb-system/monitor-metallb-speaker: servicemonitors.monitoring.coreos.com \"monitor-metallb-speaker\" is forbidden: User \"system:serviceaccount:metallb-system:default\" cannot update resource \"servicemonitors\" in API group \"monitoring.coreos.com\" in the namespace \"metallb-system\"", "errorVerbose": "servicemonitors.monitoring.coreos.com \"monitor-metallb-speaker\" is forbidden: User \"system:serviceaccount:metallb-system:default\" cannot update resource \"servicemonitors\" in API group \"monitoring.coreos.com\" in the namespace \"metallb-system\"\ncould not update object (monitoring.coreos.com/v1, Kind=ServiceMonitor) metallb-system/monitor-metallb-speaker\ngithub.com/metallb/metallb-operator/pkg/apply.ApplyObject\n\t/workspace/pkg/apply/apply.go:63\ngithub.com/metallb/metallb-operator/controllers.(*MetalLBReconciler).syncMetalLBResources\n\t/workspace/controllers/metallb_controller.go:201\ngithub.com/metallb/metallb-operator/controllers.(*MetalLBReconciler).reconcileResource\n\t/workspace/controllers/metallb_controller.go:119\ngithub.com/metallb/metallb-operator/controllers.(*MetalLBReconciler).Reconcile\n\t/workspace/controllers/metallb_controller.go:103\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler\n\t/workspace/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:263\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem\n\t/workspace/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:235\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func1.1\n\t/workspace/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:198\nk8s.io/apimachinery/pkg/util/wait.JitterUntilWithContext.func1\n\t/workspace/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:185\nk8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1\n\t/workspace/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:155\nk8s.io/apimachinery/pkg/util/wait.BackoffUntil\n\t/workspace/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:156\nk8s.io/apimachinery/pkg/util/wait.JitterUntil\n\t/workspace/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:133\nk8s.io/apimachinery/pkg/util/wait.JitterUntilWithContext\n\t/workspace/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:185\nk8s.io/apimachinery/pkg/util/wait.UntilWithContext\n\t/workspace/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:99\nruntime.goexit\n\t/usr/lib/golang/src/runtime/asm_amd64.s:1581\ncould not apply (monitoring.coreos.com/v1, Kind=ServiceMonitor) metallb-system/monitor-metallb-speaker\ngithub.com/metallb/metallb-operator/controllers.(*MetalLBReconciler).syncMetalLBResources\n\t/workspace/controllers/metallb_controller.go:202\ngithub.com/metallb/metallb-operator/controllers.(*MetalLBReconciler).reconcileResource\n\t/workspace/controllers/metallb_controller.go:119\ngithub.com/metallb/metallb-operator/controllers.(*MetalLBReconciler).Reconcile\n\t/workspace/controllers/metallb_controller.go:103\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler\n\t/workspace/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:263\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem\n\t/workspace/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:235\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func1.1\n\t/workspace/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:198\nk8s.io/apimachinery/pkg/util/wait.JitterUntilWithContext.func1\n\t/workspace/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:185\nk8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1\n\t/workspace/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:155\nk8s.io/apimachinery/pkg/util/wait.BackoffUntil\n\t/workspace/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:156\nk8s.io/apimachinery/pkg/util/wait.JitterUntil\n\t/workspace/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:133\nk8s.io/apimachinery/pkg/util/wait.JitterUntilWithContext\n\t/workspace/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:185\nk8s.io/apimachinery/pkg/util/wait.UntilWithContext\n\t/workspace/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:99\nruntime.goexit\n\t/usr/lib/golang/src/runtime/asm_amd64.s:1581\nFailedToSyncMetalLBResources\ngithub.com/metallb/metallb-operator/controllers.(*MetalLBReconciler).reconcileResource\n\t/workspace/controllers/metallb_controller.go:121\ngithub.com/metallb/metallb-operator/controllers.(*MetalLBReconciler).Reconcile\n\t/workspace/controllers/metallb_controller.go:103\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler\n\t/workspace/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:263\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem\n\t/workspace/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:235\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func1.1\n\t/workspace/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:198\nk8s.io/apimachinery/pkg/util/wait.JitterUntilWithContext.func1\n\t/workspace/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:185\nk8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1\n\t/workspace/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:155\nk8s.io/apimachinery/pkg/util/wait.BackoffUntil\n\t/workspace/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:156\nk8s.io/apimachinery/pkg/util/wait.JitterUntil\n\t/workspace/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:133\nk8s.io/apimachinery/pkg/util/wait.JitterUntilWithContext\n\t/workspace/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:185\nk8s.io/apimachinery/pkg/util/wait.UntilWithContext\n\t/workspace/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:99\nruntime.goexit\n\t/usr/lib/golang/src/runtime/asm_amd64.s:1581"}
github.com/go-logr/zapr.(*zapLogger).Error
	/workspace/vendor/github.com/go-logr/zapr/zapr.go:132
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler
	/workspace/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:267
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem
	/workspace/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:235
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func1.1
	/workspace/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:198
k8s.io/apimachinery/pkg/util/wait.JitterUntilWithContext.func1
	/workspace/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:185
k8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1
	/workspace/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:155
k8s.io/apimachinery/pkg/util/wait.BackoffUntil
	/workspace/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:156
k8s.io/apimachinery/pkg/util/wait.JitterUntil
	/workspace/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:133
k8s.io/apimachinery/pkg/util/wait.JitterUntilWithContext
	/workspace/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:185
k8s.io/apimachinery/pkg/util/wait.UntilWithContext
	/workspace/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:99
```