### PR TITLE
Remove FRR_LOGGING_LEVEL from manifests

### DIFF
--- a/bindata/deployment/frr/metallb-frr.yaml
+++ b/bindata/deployment/frr/metallb-frr.yaml
@@ -310,8 +310,8 @@ spec:
             # FRR_LOGGING_LEVEL used to set logging level for all running frr processes.
             # Possible settings are :-
             #  informational, warning, errors and debugging.
-            - name: FRR_LOGGING_LEVEL
-              value: informational
+            # - name: FRR_LOGGING_LEVEL
+            #   value: informational
             - name: METALLB_NODE_NAME
               valueFrom:
                 fieldRef:

--- a/hack/generate-metallb-manifests.sh
+++ b/hack/generate-metallb-manifests.sh
@@ -65,6 +65,8 @@ yq e --inplace '. | (select(.kind == "DaemonSet" and .metadata.name == "speaker"
 yq e --inplace '. | select(.kind == "Deployment" and .metadata.name == "controller" and .spec.template.spec.containers[0].name == "controller" and .spec.template.spec.securityContext.runAsUser == "65534").spec.template.spec.securityContext|="'"$(< ${METALLB_SC_FILE})"'"' ${FRR_MANIFESTS_DIR}/${FRR_MANIFESTS_FILE}
 yq e --inplace '. | select(.metadata.namespace == "metallb-system").metadata.namespace|="{{.NameSpace}}"' ${FRR_MANIFESTS_DIR}/${FRR_MANIFESTS_FILE}
 sed -i 's/--log-level=info/--log-level={{.LogLevel}}/' ${FRR_MANIFESTS_DIR}/${FRR_MANIFESTS_FILE}
+sed -i '/- name: FRR_LOGGING_LEVEL/ s//# &/' ${FRR_MANIFESTS_DIR}/${FRR_MANIFESTS_FILE}
+sed -i '/  value: informational/ s//# &/' ${FRR_MANIFESTS_DIR}/${FRR_MANIFESTS_FILE}
 
 # kube-rbac-proxy modifications
 yq e --inplace ". | select(.kind == \"DaemonSet\" and .metadata.name == \"speaker\").spec.template.spec.volumes += {\"name\": \"{{ if .DeployKubeRbacProxies }}\"}" ${FRR_MANIFESTS_DIR}/${FRR_MANIFESTS_FILE}


### PR DESCRIPTION
This PR relates to #154 

In order to forward the MetalLB.Spec.LogLevel value to the FRR container, the FRR_LOGGING_LEVEL env variable
must not be present. In the latter is in the manifest, the user has no chance to change the frr logging level.