### PR TITLE
Bump go to 1.17

### DIFF
--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        go: [ '1.16' ]
+        go: [ '1.17' ]
     name: Unit and Integration tests
     steps:
     - name: Checkout Metal LB Operator

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -20,7 +20,7 @@ jobs:
       built_image: "metallb-operator:ci" # Arbitrary name
     strategy:
       matrix:
-        go: [ '1.16' ]
+        go: [ '1.17' ]
     name: Go ${{ matrix.go }}
     steps:
     - name: Checkout Metal LB Operator

--- a/.github/workflows/metallb_e2e.yml
+++ b/.github/workflows/metallb_e2e.yml
@@ -18,7 +18,7 @@ jobs:
       built_image: "metallb-operator:ci" # Arbitrary name
     strategy:
       matrix:
-        go: ['1.16']
+        go: ['1.17']
     name: Go ${{ matrix.go }}
     steps:
       - name: Checkout Metal LB Operator

--- a/.github/workflows/olm.yml
+++ b/.github/workflows/olm.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        go: [ '1.16' ]
+        go: [ '1.17' ]
     name: Go ${{ matrix.go }}
     steps:
     - name: Checkout Metal LB Operator

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        go: ["1.16"]
+        go: ["1.17"]
     name: Go ${{ matrix.go }}
     steps:
       - name: Checkout Metal LB Operator

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/metallb/metallb-operator
 
-go 1.16
+go 1.17
 
 require (
 	github.com/Masterminds/goutils v1.1.1 // indirect
@@ -23,6 +23,57 @@ require (
 	k8s.io/kubernetes v1.21.1
 	k8s.io/utils v0.0.0-20201110183641-67b214c5f920
 	sigs.k8s.io/controller-runtime v0.7.0
+)
+
+require (
+	cloud.google.com/go v0.54.0 // indirect
+	github.com/beorn7/perks v1.0.1 // indirect
+	github.com/cespare/xxhash/v2 v2.1.1 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/evanphx/json-patch v4.9.0+incompatible // indirect
+	github.com/fsnotify/fsnotify v1.4.9 // indirect
+	github.com/go-logr/zapr v0.2.0 // indirect
+	github.com/gogo/protobuf v1.3.1 // indirect
+	github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e // indirect
+	github.com/golang/protobuf v1.4.3 // indirect
+	github.com/google/go-cmp v0.5.2 // indirect
+	github.com/google/gofuzz v1.1.0 // indirect
+	github.com/google/uuid v1.1.2 // indirect
+	github.com/googleapis/gnostic v0.5.1 // indirect
+	github.com/hashicorp/golang-lru v0.5.4 // indirect
+	github.com/imdario/mergo v0.3.10 // indirect
+	github.com/json-iterator/go v1.1.10 // indirect
+	github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 // indirect
+	github.com/mitchellh/reflectwalk v1.0.2 // indirect
+	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
+	github.com/modern-go/reflect2 v1.0.1 // indirect
+	github.com/nxadm/tail v1.4.4 // indirect
+	github.com/prometheus/client_golang v1.7.1 // indirect
+	github.com/prometheus/client_model v0.2.0 // indirect
+	github.com/prometheus/common v0.10.0 // indirect
+	github.com/prometheus/procfs v0.2.0 // indirect
+	github.com/spf13/pflag v1.0.5 // indirect
+	go.uber.org/atomic v1.6.0 // indirect
+	go.uber.org/multierr v1.5.0 // indirect
+	go.uber.org/zap v1.15.0 // indirect
+	golang.org/x/crypto v0.0.0-20201002170205-7f63de1d35b0 // indirect
+	golang.org/x/net v0.0.0-20201110031124-69a78807bb2b // indirect
+	golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d // indirect
+	golang.org/x/sys v0.0.0-20201112073958-5cba982894dd // indirect
+	golang.org/x/text v0.3.4 // indirect
+	golang.org/x/time v0.0.0-20200630173020-3af7569d3a1e // indirect
+	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
+	gomodules.xyz/jsonpatch/v2 v2.1.0 // indirect
+	google.golang.org/appengine v1.6.6 // indirect
+	google.golang.org/protobuf v1.25.0 // indirect
+	gopkg.in/inf.v0 v0.9.1 // indirect
+	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776 // indirect
+	k8s.io/component-base v0.20.4 // indirect
+	k8s.io/klog/v2 v2.4.0 // indirect
+	k8s.io/kube-openapi v0.0.0-20201113171705-d219536bb9fd // indirect
+	sigs.k8s.io/structured-merge-diff/v4 v4.0.2 // indirect
+	sigs.k8s.io/yaml v1.2.0 // indirect
 )
 
 replace (


### PR DESCRIPTION
We will need it to consume the latest metallb e2e tests.
