### PR TITLE
Add a way to generate a frr with webhooks on ocp manifest

### DIFF
--- a/hack/common.sh
+++ b/hack/common.sh
@@ -16,3 +16,5 @@ export GOFLAGS="${GOFLAGS:-"-mod=vendor"}"
 export PATH=$PATH:$GOPATH/bin
 
 mkdir -p _cache
+
+export METALLB_COMMIT_ID="35e41dea662b43e91b5c2a7338b92d27eb059a4d"

--- a/hack/generate-metallb-manifests.sh
+++ b/hack/generate-metallb-manifests.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 . $(dirname "$0")/common.sh
 
-METALLB_COMMIT_ID="b1cbd50148ef6ddc982a68948e873500d012646f"
 METALLB_SC_FILE=$(dirname "$0")/securityContext.yaml
 
 NATIVE_MANIFESTS_FILE="metallb-native.yaml"

--- a/hack/generate_ocp_webhook_manifests.sh
+++ b/hack/generate_ocp_webhook_manifests.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+. $(dirname "$0")/common.sh
+
+METALLB_PATH=_cache/metallb
+FRR_WITH_MANIFESTS_PATH=_cache/metallb-ocp-with-manifests.yaml
+
+curl -L https://github.com/metallb/metallb/tarball/"$METALLB_COMMIT_ID" | tar zx -C _cache
+rm -rf "$METALLB_PATH"
+mv _cache/metallb-metallb-* "$METALLB_PATH"
+kubectl kustomize hack/ocp-kustomize-overlay > $FRR_WITH_MANIFESTS_PATH

--- a/hack/ocp-kustomize-overlay/controller-webhook-patch.yaml
+++ b/hack/ocp-kustomize-overlay/controller-webhook-patch.yaml
@@ -1,0 +1,27 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: controller
+  namespace: metallb-system
+spec:
+  template:
+    spec:
+      containers:
+      - name: controller
+        ports:
+        - containerPort: 9443
+          name: webhook-server
+          protocol: TCP
+        volumeMounts:
+        - mountPath: /tmp/k8s-webhook-server/serving-certs
+          name: cert
+          readOnly: true
+        args:
+        - --enable-webhook
+        - --port=7472
+        - --log-level=info
+      volumes:
+      - name: cert
+        secret:
+          defaultMode: 420
+          secretName: webhook-server-cert

--- a/hack/ocp-kustomize-overlay/crd-conversion-patch.yaml
+++ b/hack/ocp-kustomize-overlay/crd-conversion-patch.yaml
@@ -1,0 +1,37 @@
+# The following patch enables conversion webhook for CRD
+# CRD conversion requires k8s 1.13 or later.
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: addresspools.metallb.io
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      conversionReviewVersions: ["v1alpha1", "v1beta1"]
+      clientConfig:
+        # this is "\n" used as a placeholder, otherwise it will be rejected by the apiserver for being blank,
+        # but we're going to set it later using the cert-manager (or potentially a patch if not using cert-manager)
+        caBundle: Cg==
+        service:
+          namespace: system
+          name: webhook-service
+          path: /convert
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: bgppeers.metallb.io
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      conversionReviewVersions: ["v1beta1", "v1beta2"]
+      clientConfig:
+        # this is "\n" used as a placeholder, otherwise it will be rejected by the apiserver for being blank,
+        # but we're going to set it later using the cert-manager (or potentially a patch if not using cert-manager)
+        caBundle: Cg==
+        service:
+          namespace: system-metallb
+          name: webhook-service
+          path: /convert

--- a/hack/ocp-kustomize-overlay/crdcainjection-patch.yaml
+++ b/hack/ocp-kustomize-overlay/crdcainjection-patch.yaml
@@ -1,0 +1,13 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition 
+metadata:
+  annotations:                 
+    service.beta.openshift.io/inject-cabundle: "true"
+  name: addresspools.metallb.io
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition 
+metadata:
+  annotations:                 
+    service.beta.openshift.io/inject-cabundle: "true"
+  name: bgppeers.metallb.io

--- a/hack/ocp-kustomize-overlay/kustomization.yaml
+++ b/hack/ocp-kustomize-overlay/kustomization.yaml
@@ -1,0 +1,16 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../_cache/metallb/config/frr
+  - ../../_cache/metallb/config/webhook
+  - rbac.yaml
+
+patchesStrategicMerge:
+  - controller-webhook-patch.yaml
+  - webhookcainjection-patch.yaml
+  - crd-conversion-patch.yaml
+  - crdcainjection-patch.yaml
+  - webhookservicecainjection_patch.yaml
+  - permission-patch.yaml
+
+namespace: metallb-system

--- a/hack/ocp-kustomize-overlay/permission-patch.yaml
+++ b/hack/ocp-kustomize-overlay/permission-patch.yaml
@@ -1,0 +1,25 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: controller
+  namespace: metallb-system
+spec:
+  template:
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        $patch: replace
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: speaker
+  namespace: metallb-system
+spec:
+  template:
+    spec:
+      initContainers:
+        - name: cp-frr-files
+          securityContext:
+            $patch: delete
+

--- a/hack/ocp-kustomize-overlay/rbac.yaml
+++ b/hack/ocp-kustomize-overlay/rbac.yaml
@@ -1,0 +1,28 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: allow-privileged
+rules:
+  - apiGroups:
+      - security.openshift.io
+    resourceNames:
+      - privileged
+    resources:
+      - securitycontextconstraints
+    verbs:
+      - use
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: metallb-allow-privileged
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: allow-privileged
+subjects:
+  - kind: ServiceAccount
+    name: speaker
+    namespace: metallb-system
+---
+

--- a/hack/ocp-kustomize-overlay/webhookcainjection-patch.yaml
+++ b/hack/ocp-kustomize-overlay/webhookcainjection-patch.yaml
@@ -1,0 +1,7 @@
+# This patch add annotation to admission webhook config
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: validating-webhook-configuration
+  annotations:
+    service.beta.openshift.io/inject-cabundle: "true"

--- a/hack/ocp-kustomize-overlay/webhookservicecainjection_patch.yaml
+++ b/hack/ocp-kustomize-overlay/webhookservicecainjection_patch.yaml
@@ -1,0 +1,8 @@
+# This patch add annotation to the webhook service config
+apiVersion: v1
+kind: Service
+metadata:
+  name: webhook-service
+  namespace: system
+  annotations:
+    service.alpha.openshift.io/serving-cert-secret-name: webhook-server-cert


### PR DESCRIPTION
We add a local overlay and we clone metallb to build a full manifest with the webhook settings for metallb so we don't tamper metallb with ocp specific content. The operator is already aware of openshift.
