### PR TITLE
Add upgrade CI job

### DIFF
--- a/.github/workflows/upgrade.yml
+++ b/.github/workflows/upgrade.yml
@@ -1,0 +1,108 @@
+name: Upgrade
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches:
+      - main
+      - "v[0-9]+.[0-9]+.[0-9]+"
+      - "v[0-9]+.[0-9]+"
+defaults:
+  run:
+    shell: bash
+    working-directory: metallboperator
+
+jobs:
+  main:
+    runs-on: ubuntu-20.04
+    env:
+      built_image_prev_release: "metallb-operator-prev-rel:ci" # Arbitrary name
+      built_image: "metallb-operator:ci" # Arbitrary name
+    strategy:
+      matrix:
+        go: [ '1.17' ]
+    name: Go ${{ matrix.go }}
+    steps:
+    - name: Checkout Previous Release Metal LB Operator
+      uses: actions/checkout@v2
+      with:
+        path: metallboperator
+        ref: v0.12 # previous release version
+        fetch-depth: 0 # Fetch all history for all tags and branches
+
+    - uses: actions/setup-go@v2
+      id: go
+      with:
+        go-version: ${{ matrix.go }}
+
+    - name: Build image
+      run: |
+        docker build . -t ${built_image_prev_release}
+    - name: Create K8s Kind Cluster
+      run: |
+        ./hack/kind-cluster-without-registry.sh
+        kind load docker-image ${built_image_prev_release}
+    - name: Deploy Previous Release Metal LB Operator
+      run: |
+        make deploy-cert-manager
+        IMG=${built_image_prev_release} KUSTOMIZE_DEPLOY_DIR="config/kind-ci/" ENABLE_OPERATOR_WEBHOOK="true" make deploy
+    - name: E2E Tests
+      run: |
+        export KUBECONFIG=${HOME}/.kube/config
+        make test-validation
+        make test-e2e
+    - name: Archive E2E Tests logs
+      if: ${{ failure() }}
+      uses: actions/upload-artifact@v2
+      with:
+        name: test_e2e_logs
+        path: /tmp/test_e2e_logs/
+    - name: Export kind logs
+      if: ${{ failure() }}
+      run: |
+        kind export logs /tmp/kind_logs
+    - name: Archive kind logs
+      if: ${{ failure() }}
+      uses: actions/upload-artifact@v2
+      with:
+        name: kind_logs
+        path: /tmp/kind_logs
+
+    - name: Checkout Latest Metal LB Operator
+      uses: actions/checkout@v2
+      with:
+        path: metallboperator-main
+        ref: main
+        fetch-depth: 0 # Fetch all history for all tags and branches
+    - name: Build image
+      run: |
+        cd ${GITHUB_WORKSPACE}/metallboperator-main
+        docker build . -t ${built_image}
+        kind load docker-image ${built_image}
+    - name: Deploy Metal LB Operator
+      run: |
+        cd ${GITHUB_WORKSPACE}/metallboperator-main
+        IMG=${built_image} KUSTOMIZE_DEPLOY_DIR="config/kind-ci/" ENABLE_WEBHOOK="true" make deploy
+    - name: E2E Tests
+      run: |
+        cd ${GITHUB_WORKSPACE}/metallboperator-main
+        export KUBECONFIG=${HOME}/.kube/config
+        make test-validation
+        make test-e2e
+    - name: Archive E2E Tests logs
+      if: ${{ failure() }}
+      uses: actions/upload-artifact@v2
+      with:
+        name: test_e2e_logs
+        path: /tmp/test_e2e_logs/
+    - name: Export kind logs
+      if: ${{ failure() }}
+      run: |
+        kind export logs /tmp/kind_logs
+    - name: Archive kind logs
+      if: ${{ failure() }}
+      uses: actions/upload-artifact@v2
+      with:
+        name: kind_logs
+        path: /tmp/kind_logs


### PR DESCRIPTION
This new CI job ensures metallb operator upgrade works seemlessly
by deploying and running tests on the previous operator version
followed by redeploying and testing on the newer operator
version.

Signed-off-by: Periyasamy Palanisamy <pepalani@redhat.com>