### PR TITLE
Expose the ports used by metrics and memberlist as parameters

### DIFF
--- a/bindata/deployment/frr-with-webhooks/metallb-frr-with-webhooks.yaml
+++ b/bindata/deployment/frr-with-webhooks/metallb-frr-with-webhooks.yaml
@@ -58,8 +58,8 @@ spec:
   hostNetwork: true
   hostPID: false
   hostPorts:
-    - max: 7472
-      min: 7472
+    - max: {{.MetricsPort}}
+      min: {{.MetricsPort}}
     - max: 7946
       min: 7946
   privileged: true
@@ -204,7 +204,7 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io/port: "7472"
+        prometheus.io/port: "{{.MetricsPort}}"
         prometheus.io/scrape: "true"
       labels:
         app: metallb
@@ -213,7 +213,7 @@ spec:
       containers:
         - args:
             - --enable-webhook
-            - --port=7472
+            - --port={{.MetricsPort}}
             - --log-level={{.LogLevel}}
           env:
             - name: METALLB_BGP_TYPE
@@ -237,7 +237,7 @@ spec:
             - containerPort: 9443
               name: webhook-server
               protocol: TCP
-            - containerPort: 7472
+            - containerPort: {{.MetricsPort}}
               name: monitoring
           readinessProbe:
             failureThreshold: 3
@@ -266,13 +266,13 @@ spec:
           imagePullPolicy: IfNotPresent
           args:
             - --logtostderr
-            - --secure-listen-address=:27472
+            - --secure-listen-address=:{{.MetricsPortHttps}}
             - --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_RSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256
-            - --upstream=http://$(METALLB_HOST):7472/
+            - --upstream=http://$(METALLB_HOST):{{.MetricsPort}}/
             - --tls-private-key-file=/etc/metrics/tls.key
             - --tls-cert-file=/etc/metrics/tls.crt
           ports:
-            - containerPort: 27472
+            - containerPort: {{.MetricsPortHttps}}
               name: https-metrics
           env:
             - name: METALLB_HOST
@@ -325,7 +325,7 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io/port: "7472"
+        prometheus.io/port: "{{.MetricsPort}}"
         prometheus.io/scrape: "true"
       labels:
         app: metallb
@@ -372,13 +372,13 @@ spec:
             - mountPath: /etc/frr_reloader
               name: reloader
         - args:
-            - --metrics-port=7473
+            - --metrics-port={{.FRRMetricsPort}}
           command:
             - /etc/frr_metrics/frr-metrics
           image: '{{.FRRImage}}'
           name: frr-metrics
           ports:
-            - containerPort: 7473
+            - containerPort: {{.FRRMetricsPort}}
               name: monitoring
           volumeMounts:
             - mountPath: /var/run/frr
@@ -388,8 +388,9 @@ spec:
             - mountPath: /etc/frr_metrics
               name: metrics
         - args:
-            - --port=7472
+            - --port={{.MetricsPort}}
             - --log-level={{.LogLevel}}
+            - --ml-bindport={{.MLBindPort}}
           env:
             - name: FRR_CONFIG_FILE
               value: /etc/frr_reloader/frr.conf
@@ -430,7 +431,7 @@ spec:
             timeoutSeconds: 1
           name: speaker
           ports:
-            - containerPort: 7472
+            - containerPort: {{.MetricsPort}}
               name: monitoring
             - containerPort: 7946
               name: memberlist-tcp
@@ -465,13 +466,13 @@ spec:
           imagePullPolicy: IfNotPresent
           args:
             - --logtostderr
-            - --secure-listen-address=:27473
+            - --secure-listen-address=:{{.FRRMetricsPortHttps}}
             - --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_RSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256
-            - --upstream=http://127.0.0.1:7473/
+            - --upstream=http://127.0.0.1:{{.FRRMetricsPort}}/
             - --tls-private-key-file=/etc/metrics/tls.key
             - --tls-cert-file=/etc/metrics/tls.crt
           ports:
-            - containerPort: 27473
+            - containerPort: {{.FRRMetricsPortHttps}}
               name: https-metrics
           resources:
             requests:
@@ -487,13 +488,13 @@ spec:
           imagePullPolicy: IfNotPresent
           args:
             - --logtostderr
-            - --secure-listen-address=:27472
+            - --secure-listen-address=:{{.MetricsPortHttps}}
             - --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_RSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256
-            - --upstream=http://$(METALLB_HOST):7472/
+            - --upstream=http://$(METALLB_HOST):{{.MetricsPort}}/
             - --tls-private-key-file=/etc/metrics/tls.key
             - --tls-cert-file=/etc/metrics/tls.crt
           ports:
-            - containerPort: 27472
+            - containerPort: {{.MetricsPortHttps}}
               name: https-metrics
           env:
             - name: METALLB_HOST

--- a/bindata/deployment/frr/metallb-frr.yaml
+++ b/bindata/deployment/frr/metallb-frr.yaml
@@ -58,8 +58,8 @@ spec:
   hostNetwork: true
   hostPID: false
   hostPorts:
-    - max: 7472
-      min: 7472
+    - max: {{.MetricsPort}}
+      min: {{.MetricsPort}}
     - max: 7946
       min: 7946
   privileged: true
@@ -192,7 +192,7 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io/port: "7472"
+        prometheus.io/port: "{{.MetricsPort}}"
         prometheus.io/scrape: "true"
       labels:
         app: metallb
@@ -200,7 +200,7 @@ spec:
     spec:
       containers:
         - args:
-            - --port=7472
+            - --port={{.MetricsPort}}
             - --log-level={{.LogLevel}}
           env:
             - name: METALLB_BGP_TYPE
@@ -221,7 +221,7 @@ spec:
             timeoutSeconds: 1
           name: controller
           ports:
-            - containerPort: 7472
+            - containerPort: {{.MetricsPort}}
               name: monitoring
           readinessProbe:
             failureThreshold: 3
@@ -246,13 +246,13 @@ spec:
           imagePullPolicy: IfNotPresent
           args:
             - --logtostderr
-            - --secure-listen-address=:27472
+            - --secure-listen-address=:{{.MetricsPortHttps}}
             - --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_RSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256
-            - --upstream=http://$(METALLB_HOST):7472/
+            - --upstream=http://$(METALLB_HOST):{{.MetricsPort}}/
             - --tls-private-key-file=/etc/metrics/tls.key
             - --tls-cert-file=/etc/metrics/tls.crt
           ports:
-            - containerPort: 27472
+            - containerPort: {{.MetricsPortHttps}}
               name: https-metrics
           env:
             - name: METALLB_HOST
@@ -301,7 +301,7 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io/port: "7472"
+        prometheus.io/port: "{{.MetricsPort}}"
         prometheus.io/scrape: "true"
       labels:
         app: metallb
@@ -348,13 +348,13 @@ spec:
             - mountPath: /etc/frr_reloader
               name: reloader
         - args:
-            - --metrics-port=7473
+            - --metrics-port={{.FRRMetricsPort}}
           command:
             - /etc/frr_metrics/frr-metrics
           image: '{{.FRRImage}}'
           name: frr-metrics
           ports:
-            - containerPort: 7473
+            - containerPort: {{.FRRMetricsPort}}
               name: monitoring
           volumeMounts:
             - mountPath: /var/run/frr
@@ -364,8 +364,9 @@ spec:
             - mountPath: /etc/frr_metrics
               name: metrics
         - args:
-            - --port=7472
+            - --port={{.MetricsPort}}
             - --log-level={{.LogLevel}}
+            - --ml-bindport={{.MLBindPort}}
           env:
             - name: FRR_CONFIG_FILE
               value: /etc/frr_reloader/frr.conf
@@ -406,7 +407,7 @@ spec:
             timeoutSeconds: 1
           name: speaker
           ports:
-            - containerPort: 7472
+            - containerPort: {{.MetricsPort}}
               name: monitoring
             - containerPort: 7946
               name: memberlist-tcp
@@ -441,13 +442,13 @@ spec:
           imagePullPolicy: IfNotPresent
           args:
             - --logtostderr
-            - --secure-listen-address=:27473
+            - --secure-listen-address=:{{.FRRMetricsPortHttps}}
             - --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_RSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256
-            - --upstream=http://127.0.0.1:7473/
+            - --upstream=http://127.0.0.1:{{.FRRMetricsPort}}/
             - --tls-private-key-file=/etc/metrics/tls.key
             - --tls-cert-file=/etc/metrics/tls.crt
           ports:
-            - containerPort: 27473
+            - containerPort: {{.FRRMetricsPortHttps}}
               name: https-metrics
           resources:
             requests:
@@ -463,13 +464,13 @@ spec:
           imagePullPolicy: IfNotPresent
           args:
             - --logtostderr
-            - --secure-listen-address=:27472
+            - --secure-listen-address=:{{.MetricsPortHttps}}
             - --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_RSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256
-            - --upstream=http://$(METALLB_HOST):7472/
+            - --upstream=http://$(METALLB_HOST):{{.MetricsPort}}/
             - --tls-private-key-file=/etc/metrics/tls.key
             - --tls-cert-file=/etc/metrics/tls.crt
           ports:
-            - containerPort: 27472
+            - containerPort: {{.MetricsPortHttps}}
               name: https-metrics
           env:
             - name: METALLB_HOST

--- a/bindata/deployment/native-with-webhooks/metallb-native-with-webhooks.yaml
+++ b/bindata/deployment/native-with-webhooks/metallb-native-with-webhooks.yaml
@@ -58,8 +58,8 @@ spec:
   hostNetwork: true
   hostPID: false
   hostPorts:
-    - max: 7472
-      min: 7472
+    - max: {{.MetricsPort}}
+      min: {{.MetricsPort}}
     - max: 7946
       min: 7946
   privileged: true
@@ -106,7 +106,7 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io/port: "7472"
+        prometheus.io/port: "{{.MetricsPort}}"
         prometheus.io/scrape: "true"
       labels:
         app: metallb
@@ -115,7 +115,7 @@ spec:
       containers:
         - args:
             - --enable-webhook
-            - --port=7472
+            - --port={{.MetricsPort}}
             - --log-level={{.LogLevel}}
           env:
             - name: METALLB_ML_SECRET_NAME
@@ -137,7 +137,7 @@ spec:
             - containerPort: 9443
               name: webhook-server
               protocol: TCP
-            - containerPort: 7472
+            - containerPort: {{.MetricsPort}}
               name: monitoring
           readinessProbe:
             failureThreshold: 3
@@ -191,7 +191,7 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io/port: "7472"
+        prometheus.io/port: "{{.MetricsPort}}"
         prometheus.io/scrape: "true"
       labels:
         app: metallb
@@ -199,8 +199,9 @@ spec:
     spec:
       containers:
         - args:
-            - --port=7472
+            - --port={{.MetricsPort}}
             - --log-level={{.LogLevel}}
+            - --ml-bindport={{.MLBindPort}}
           env:
             - name: METALLB_NODE_NAME
               valueFrom:
@@ -233,7 +234,7 @@ spec:
             timeoutSeconds: 1
           name: speaker
           ports:
-            - containerPort: 7472
+            - containerPort: {{.MetricsPort}}
               name: monitoring
             - containerPort: 7946
               name: memberlist-tcp

--- a/bindata/deployment/native/metallb-native.yaml
+++ b/bindata/deployment/native/metallb-native.yaml
@@ -58,8 +58,8 @@ spec:
   hostNetwork: true
   hostPID: false
   hostPorts:
-    - max: 7472
-      min: 7472
+    - max: {{.MetricsPort}}
+      min: {{.MetricsPort}}
     - max: 7946
       min: 7946
   privileged: true
@@ -94,7 +94,7 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io/port: "7472"
+        prometheus.io/port: "{{.MetricsPort}}"
         prometheus.io/scrape: "true"
       labels:
         app: metallb
@@ -102,7 +102,7 @@ spec:
     spec:
       containers:
         - args:
-            - --port=7472
+            - --port={{.MetricsPort}}
             - --log-level={{.LogLevel}}
           env:
             - name: METALLB_ML_SECRET_NAME
@@ -121,7 +121,7 @@ spec:
             timeoutSeconds: 1
           name: controller
           ports:
-            - containerPort: 7472
+            - containerPort: {{.MetricsPort}}
               name: monitoring
           readinessProbe:
             failureThreshold: 3
@@ -166,7 +166,7 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io/port: "7472"
+        prometheus.io/port: "{{.MetricsPort}}"
         prometheus.io/scrape: "true"
       labels:
         app: metallb
@@ -174,8 +174,9 @@ spec:
     spec:
       containers:
         - args:
-            - --port=7472
+            - --port={{.MetricsPort}}
             - --log-level={{.LogLevel}}
+            - --ml-bindport={{.MLBindPort}}
           env:
             - name: METALLB_NODE_NAME
               valueFrom:
@@ -208,7 +209,7 @@ spec:
             timeoutSeconds: 1
           name: speaker
           ports:
-            - containerPort: 7472
+            - containerPort: {{.MetricsPort}}
               name: monitoring
             - containerPort: 7946
               name: memberlist-tcp

--- a/bindata/deployment/openshift/metallb-openshift.yaml
+++ b/bindata/deployment/openshift/metallb-openshift.yaml
@@ -58,8 +58,8 @@ spec:
   hostNetwork: true
   hostPID: false
   hostPorts:
-    - max: 7472
-      min: 7472
+    - max: {{.MetricsPort}}
+      min: {{.MetricsPort}}
     - max: 7946
       min: 7946
   privileged: true
@@ -206,7 +206,7 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io/port: "7472"
+        prometheus.io/port: "{{.MetricsPort}}"
         prometheus.io/scrape: "true"
       labels:
         app: metallb
@@ -215,7 +215,7 @@ spec:
       containers:
         - args:
             - --enable-webhook
-            - --port=7472
+            - --port={{.MetricsPort}}
             - --log-level={{.LogLevel}}
           env:
             - name: METALLB_BGP_TYPE
@@ -239,7 +239,7 @@ spec:
             - containerPort: 9443
               name: webhook-server
               protocol: TCP
-            - containerPort: 7472
+            - containerPort: {{.MetricsPort}}
               name: monitoring
           readinessProbe:
             failureThreshold: 3
@@ -268,13 +268,13 @@ spec:
           imagePullPolicy: IfNotPresent
           args:
             - --logtostderr
-            - --secure-listen-address=:27472
+            - --secure-listen-address=:{{.MetricsPortHttps}}
             - --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_RSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256
-            - --upstream=http://$(METALLB_HOST):7472/
+            - --upstream=http://$(METALLB_HOST):{{.MetricsPort}}/
             - --tls-private-key-file=/etc/metrics/tls.key
             - --tls-cert-file=/etc/metrics/tls.crt
           ports:
-            - containerPort: 27472
+            - containerPort: {{.MetricsPortHttps}}
               name: https-metrics
           env:
             - name: METALLB_HOST
@@ -327,7 +327,7 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io/port: "7472"
+        prometheus.io/port: "{{.MetricsPort}}"
         prometheus.io/scrape: "true"
       labels:
         app: metallb
@@ -374,13 +374,13 @@ spec:
             - mountPath: /etc/frr_reloader
               name: reloader
         - args:
-            - --metrics-port=7473
+            - --metrics-port={{.FRRMetricsPort}}
           command:
             - /etc/frr_metrics/frr-metrics
           image: '{{.FRRImage}}'
           name: frr-metrics
           ports:
-            - containerPort: 7473
+            - containerPort: {{.FRRMetricsPort}}
               name: monitoring
           volumeMounts:
             - mountPath: /var/run/frr
@@ -390,8 +390,9 @@ spec:
             - mountPath: /etc/frr_metrics
               name: metrics
         - args:
-            - --port=7472
+            - --port={{.MetricsPort}}
             - --log-level={{.LogLevel}}
+            - --ml-bindport={{.MLBindPort}}
           env:
             - name: FRR_CONFIG_FILE
               value: /etc/frr_reloader/frr.conf
@@ -432,7 +433,7 @@ spec:
             timeoutSeconds: 1
           name: speaker
           ports:
-            - containerPort: 7472
+            - containerPort: {{.MetricsPort}}
               name: monitoring
             - containerPort: 7946
               name: memberlist-tcp
@@ -467,13 +468,13 @@ spec:
           imagePullPolicy: IfNotPresent
           args:
             - --logtostderr
-            - --secure-listen-address=:27473
+            - --secure-listen-address=:{{.FRRMetricsPortHttps}}
             - --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_RSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256
-            - --upstream=http://127.0.0.1:7473/
+            - --upstream=http://127.0.0.1:{{.FRRMetricsPort}}/
             - --tls-private-key-file=/etc/metrics/tls.key
             - --tls-cert-file=/etc/metrics/tls.crt
           ports:
-            - containerPort: 27473
+            - containerPort: {{.FRRMetricsPortHttps}}
               name: https-metrics
           resources:
             requests:
@@ -489,13 +490,13 @@ spec:
           imagePullPolicy: IfNotPresent
           args:
             - --logtostderr
-            - --secure-listen-address=:27472
+            - --secure-listen-address=:{{.MetricsPortHttps}}
             - --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_RSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256
-            - --upstream=http://$(METALLB_HOST):7472/
+            - --upstream=http://$(METALLB_HOST):{{.MetricsPort}}/
             - --tls-private-key-file=/etc/metrics/tls.key
             - --tls-cert-file=/etc/metrics/tls.crt
           ports:
-            - containerPort: 27472
+            - containerPort: {{.MetricsPortHttps}}
               name: https-metrics
           env:
             - name: METALLB_HOST

--- a/hack/kube-rbac-controller.json
+++ b/hack/kube-rbac-controller.json
@@ -4,15 +4,15 @@
     "imagePullPolicy": "IfNotPresent",
     "args": [
       "--logtostderr",
-      "--secure-listen-address=:27472",
+      "--secure-listen-address=:{{.MetricsPortHttps}}",
       "--tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_RSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256",
-      "--upstream=http://$(METALLB_HOST):7472/",
+      "--upstream=http://$(METALLB_HOST):{{.MetricsPort}}/",
       "--tls-private-key-file=/etc/metrics/tls.key",
       "--tls-cert-file=/etc/metrics/tls.crt"
     ],
     "ports": [
       {
-        "containerPort": 27472,
+        "containerPort": "{{.MetricsPortHttps}}",
         "name": "https-metrics"
       }
     ],

--- a/hack/kube-rbac-frr.json
+++ b/hack/kube-rbac-frr.json
@@ -4,15 +4,15 @@
     "imagePullPolicy": "IfNotPresent",
     "args": [
       "--logtostderr",
-      "--secure-listen-address=:27473",
+      "--secure-listen-address=:{{.FRRMetricsPortHttps}}",
       "--tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_RSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256",
-      "--upstream=http://127.0.0.1:7473/",
+      "--upstream=http://127.0.0.1:{{.FRRMetricsPort}}/",
       "--tls-private-key-file=/etc/metrics/tls.key",
       "--tls-cert-file=/etc/metrics/tls.crt"
     ],
     "ports": [
       {
-        "containerPort": 27473,
+        "containerPort": "{{.FRRMetricsPortHttps}}",
         "name": "https-metrics"
       }
     ],

--- a/hack/kube-rbac-speaker.json
+++ b/hack/kube-rbac-speaker.json
@@ -4,15 +4,15 @@
     "imagePullPolicy": "IfNotPresent",
     "args": [
       "--logtostderr",
-      "--secure-listen-address=:27472",
+      "--secure-listen-address=:{{.MetricsPortHttps}}",
       "--tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_RSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256",
-      "--upstream=http://$(METALLB_HOST):7472/",
+      "--upstream=http://$(METALLB_HOST):{{.MetricsPort}}/",
       "--tls-private-key-file=/etc/metrics/tls.key",
       "--tls-cert-file=/etc/metrics/tls.crt"
     ],
     "ports": [
       {
-        "containerPort": 27472,
+        "containerPort": "{{.MetricsPortHttps}}",
         "name": "https-metrics"
       }
     ],


### PR DESCRIPTION
Given the speaker is a hostnetworked pod, we want to be able to configure the ports used by it in order to avoid conflicts with other processes.