### PR TITLE
Run backward compatible tests

### DIFF
--- a/.github/workflows/metallb_e2e.yml
+++ b/.github/workflows/metallb_e2e.yml
@@ -45,7 +45,7 @@ jobs:
         with:
           repository: metallb/metallb
           path: metallb
-          ref: 9985a602b7c93a51dcce6c5d6f9bb4ec98760115
+          ref: 25a037f08201eb9a88668805684d7cecb36cea44
       - name: Checkout MetalLB v0.12.1
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/metallb_e2e.yml
+++ b/.github/workflows/metallb_e2e.yml
@@ -18,7 +18,7 @@ jobs:
       built_image: "metallb-operator:ci" # Arbitrary name
     strategy:
       matrix:
-        go: ['1.17']
+        go: ["1.17"]
     name: Go ${{ matrix.go }}
     steps:
       - name: Checkout Metal LB Operator
@@ -46,6 +46,12 @@ jobs:
           repository: metallb/metallb
           path: metallb
           ref: 9985a602b7c93a51dcce6c5d6f9bb4ec98760115
+      - name: Checkout MetalLB v0.12.1
+        uses: actions/checkout@v2
+        with:
+          repository: metallb/metallb
+          path: metallb-0.12.1
+          ref: v0.12.1
       - name: Install Dependencies
         run: |
           sudo apt-get update
@@ -62,12 +68,26 @@ jobs:
         run: |
           make deploy-cert-manager
           IMG=${built_image} KUSTOMIZE_DEPLOY_DIR="config/frr-on-ci/" ENABLE_WEBHOOK="true" make deploy
-      - name: MetalLB E2E Tests
+      - name: Enable MetalLB
         run: |
           export KUBECONFIG=${HOME}/.kube/config
           kubectl apply -f config/samples/metallb.yaml
+      - name: MetalLB E2E Tests
+        run: |
           cd ${GITHUB_WORKSPACE}/metallb
           sudo -E env "PATH=$PATH" inv e2etest --skip "IPV6|DUALSTACK" -e /tmp/kind_logs
+      - name: MetalLB E2E Tests - backward compatible
+        run: |
+          cat <<EOF | kubectl apply -f -
+          apiVersion: v1
+          kind: ConfigMap
+          metadata:
+            namespace: metallb-system
+            name: config
+          EOF
+          cd ${GITHUB_WORKSPACE}/metallb-0.12.1
+          FOCUS="L2.*should work for ExternalTrafficPolicy=Cluster|BGP.*A service of protocol load balancer should work with.*IPV4 - ExternalTrafficPolicyCluster$|validate FRR running configuration"
+          sudo -E env "PATH=$PATH" inv e2etest --use-operator --focus "$FOCUS" -e /tmp/kind_logs
       - name: Change permissions for kind logs
         if: ${{ failure() }}
         run: |

--- a/bin/metallb-operator-with-webhooks.yaml
+++ b/bin/metallb-operator-with-webhooks.yaml
@@ -108,10 +108,15 @@ spec:
     storage: false
     subresources:
       status: {}
-  - name: v1beta1
+  - deprecated: true
+    deprecationWarning: metallbio.io v1beta1 AddressPool is deprecated, consider using
+      IPAddressPool
+    name: v1beta1
     schema:
       openAPIV3Schema:
-        description: AddressPool is the Schema for the addresspools API.
+        description: AddressPool represents a pool of IP addresses that can be allocated
+          to LoadBalancer services. AddressPool is deprecated and being replaced by
+          IPAddressPool.
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -147,8 +152,8 @@ spec:
                   to be used by a pool.
                 type: boolean
               bgpAdvertisements:
-                description: When an IP is allocated from this pool, how should it
-                  be translated into BGP announcements?
+                description: Drives how an IP allocated from this pool should translated
+                  into BGP announcements.
                 items:
                   properties:
                     aggregationLength:
@@ -165,7 +170,8 @@ spec:
                       format: int32
                       type: integer
                     communities:
-                      description: BGP communities
+                      description: BGP communities to be associated with the given
+                        advertisement.
                       items:
                         type: string
                       type: array
@@ -224,7 +230,8 @@ spec:
   - name: v1beta1
     schema:
       openAPIV3Schema:
-        description: BFDProfile is the Schema for the bfdprofiles API.
+        description: BFDProfile represents the settings of the bfd session that can
+          be optionally associated with a BGP session.
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -242,30 +249,48 @@ spec:
             description: BFDProfileSpec defines the desired state of BFDProfile.
             properties:
               detectMultiplier:
+                description: Configures the detection multiplier to determine packet
+                  loss. The remote transmission interval will be multiplied by this
+                  value to determine the connection loss detection timer.
                 format: int32
                 maximum: 255
                 minimum: 2
                 type: integer
               echoInterval:
+                description: Configures the minimal echo receive transmission interval
+                  that this system is capable of handling in milliseconds. Defaults
+                  to 50ms
                 format: int32
                 maximum: 60000
                 minimum: 10
                 type: integer
               echoMode:
+                description: Enables or disables the echo transmission mode. This
+                  mode is disabled by default, and not supported on multi hops setups.
                 type: boolean
               minimumTtl:
+                description: 'For multi hop sessions only: configure the minimum expected
+                  TTL for an incoming BFD control packet.'
                 format: int32
                 maximum: 254
                 minimum: 1
                 type: integer
               passiveMode:
+                description: 'Mark session as passive: a passive session will not
+                  attempt to start the connection and will wait for control packets
+                  from peer before it begins replying.'
                 type: boolean
               receiveInterval:
+                description: The minimum interval that this system is capable of receiving
+                  control packets in milliseconds. Defaults to 300ms.
                 format: int32
                 maximum: 60000
                 minimum: 10
                 type: integer
               transmitInterval:
+                description: The minimum transmission interval (less jitter) that
+                  this system wants to use to send BFD control packets in milliseconds.
+                  Defaults to 300ms
                 format: int32
                 maximum: 60000
                 minimum: 10
@@ -305,7 +330,8 @@ spec:
   - name: v1beta1
     schema:
       openAPIV3Schema:
-        description: BGPAdvertisement is the Schema for the bgpadvertisements API.
+        description: BGPAdvertisement allows to advertise the IPs coming from the
+          selected IPAddressPools via BGP, setting the parameters of the BGP Advertisement.
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -325,24 +351,29 @@ spec:
               aggregationLength:
                 default: 32
                 description: The aggregation-length advertisement option lets you
-                  “roll up” the /32s into a larger prefix.
+                  “roll up” the /32s into a larger prefix. Defaults to 32. Works for
+                  IPv4 addresses.
                 format: int32
                 minimum: 1
                 type: integer
               aggregationLengthV6:
                 default: 128
-                description: Optional, defaults to 128 (i.e. no aggregation) if not
-                  specified.
+                description: The aggregation-length advertisement option lets you
+                  “roll up” the /128s into a larger prefix. Defaults to 128. Works
+                  for IPv6 addresses.
                 format: int32
                 type: integer
               communities:
-                description: BGP communities
+                description: The BGP communities to be associated with the announcement.
+                  Each item can be a community of the form 1234:1234 or the name of
+                  an alias defined in the Community CRD.
                 items:
                   type: string
                 type: array
               ipAddressPoolSelectors:
-                description: IPAddressPoolSelectors is a selector for the ipaddresspools
-                  which would get advertised via this advertisement.
+                description: A selector for the IPAddressPools which would get advertised
+                  via this advertisement. If no IPAddressPool is selected by this
+                  or by the list, the advertisement is applied to all the IPAddressPools.
                 items:
                   description: A label selector is a label query over a set of resources.
                     The result of matchLabels and matchExpressions are ANDed. An empty
@@ -392,20 +423,21 @@ spec:
                   type: object
                 type: array
               ipAddressPools:
-                description: IPAddressPools is the list of ipaddresspools to advertise
-                  via this advertisement.
+                description: The list of IPAddressPools to advertise via this advertisement,
+                  selected by name.
                 items:
                   type: string
                 type: array
               localPref:
-                description: BGP LOCAL_PREF attribute which is used by BGP best path
-                  algorithm, Path with higher localpref is preferred over one with
-                  lower localpref.
+                description: The BGP LOCAL_PREF attribute which is used by BGP best
+                  path algorithm, Path with higher localpref is preferred over one
+                  with lower localpref.
                 format: int32
                 type: integer
               nodeSelectors:
-                description: NodeSelectors is a selector on the node we should perform
-                  this advertisement from.
+                description: NodeSelectors allows to limit the nodes to announce as
+                  next hops for the LoadBalancer IP. When empty, all the nodes having  are
+                  announced as next hops.
                 items:
                   description: A label selector is a label query over a set of resources.
                     The result of matchLabels and matchExpressions are ANDed. An empty
@@ -455,8 +487,9 @@ spec:
                   type: object
                 type: array
               peers:
-                description: Peers are used to declare the intent of announcing the
-                  IPs of IPPools only to the Peers in this list.
+                description: Peers limits the bgppeer to advertise the ips of the
+                  selected pools to. When empty, the loadbalancer IP is announced
+                  to all the BGPPeers configured.
                 items:
                   type: string
                 type: array
@@ -616,9 +649,13 @@ spec:
             description: BGPPeerSpec defines the desired state of Peer.
             properties:
               bfdProfile:
+                description: The name of the BFD Profile to be used for the BFD session
+                  associated to the BGP session. If not set, the BFD session won't
+                  be set up.
                 type: string
               ebgpMultiHop:
-                description: EBGP peer is multi-hops away
+                description: To set if the BGPPeer is multi-hops away. Needed for
+                  FRR mode only.
                 type: boolean
               holdTime:
                 description: Requested BGP hold time, per RFC4271.
@@ -711,6 +748,7 @@ spec:
                 type: string
               peerPort:
                 default: 179
+                description: Port to dial when establishing the session.
                 maximum: 16384
                 minimum: 0
                 type: integer
@@ -759,7 +797,8 @@ spec:
   - name: v1beta1
     schema:
       openAPIV3Schema:
-        description: Community is the Schema for the communities API.
+        description: Community is a collection of aliases for communities. Users can
+          define named aliases to be used in the BGPPeer CRD.
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -780,10 +819,11 @@ spec:
                 items:
                   properties:
                     name:
-                      description: Name or identifier for the community.
+                      description: The name of the alias for the community.
                       type: string
                     value:
-                      description: BGP community value.
+                      description: The BGP community value corresponding to the given
+                        name.
                       type: string
                   type: object
                 type: array
@@ -822,7 +862,8 @@ spec:
   - name: v1beta1
     schema:
       openAPIV3Schema:
-        description: IPAddressPool is the Schema for the IPAddressPools API.
+        description: IPAddressPool represents a pool of IP addresses that can be allocated
+          to LoadBalancer services.
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -896,7 +937,8 @@ spec:
   - name: v1beta1
     schema:
       openAPIV3Schema:
-        description: L2Advertisement is the Schema for the l2advertisements API.
+        description: L2Advertisement allows to advertise the LoadBalancer IPs provided
+          by the selected pools via L2.
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -914,8 +956,9 @@ spec:
             description: L2AdvertisementSpec defines the desired state of L2Advertisement.
             properties:
               ipAddressPoolSelectors:
-                description: IPAddressPoolSelectors is a selector for the ipaddresspools
-                  which would get advertised via this advertisement.
+                description: A selector for the IPAddressPools which would get advertised
+                  via this advertisement. If no IPAddressPool is selected by this
+                  or by the list, the advertisement is applied to all the IPAddressPools.
                 items:
                   description: A label selector is a label query over a set of resources.
                     The result of matchLabels and matchExpressions are ANDed. An empty
@@ -965,14 +1008,15 @@ spec:
                   type: object
                 type: array
               ipAddressPools:
-                description: IPAddressPools is the list of ipaddresspools to advertise
-                  via this advertisement.
+                description: The list of IPAddressPools to advertise via this advertisement,
+                  selected by name.
                 items:
                   type: string
                 type: array
               nodeSelectors:
-                description: NodeSelectors is a selector on the node we should perform
-                  this advertisement from.
+                description: NodeSelectors allows to limit the nodes to announce as
+                  next hops for the LoadBalancer IP. When empty, all the nodes having  are
+                  announced as next hops.
                 items:
                   description: A label selector is a label query over a set of resources.
                     The result of matchLabels and matchExpressions are ANDed. An empty

--- a/bin/metallb-operator.yaml
+++ b/bin/metallb-operator.yaml
@@ -108,10 +108,15 @@ spec:
     storage: false
     subresources:
       status: {}
-  - name: v1beta1
+  - deprecated: true
+    deprecationWarning: metallbio.io v1beta1 AddressPool is deprecated, consider using
+      IPAddressPool
+    name: v1beta1
     schema:
       openAPIV3Schema:
-        description: AddressPool is the Schema for the addresspools API.
+        description: AddressPool represents a pool of IP addresses that can be allocated
+          to LoadBalancer services. AddressPool is deprecated and being replaced by
+          IPAddressPool.
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -147,8 +152,8 @@ spec:
                   to be used by a pool.
                 type: boolean
               bgpAdvertisements:
-                description: When an IP is allocated from this pool, how should it
-                  be translated into BGP announcements?
+                description: Drives how an IP allocated from this pool should translated
+                  into BGP announcements.
                 items:
                   properties:
                     aggregationLength:
@@ -165,7 +170,8 @@ spec:
                       format: int32
                       type: integer
                     communities:
-                      description: BGP communities
+                      description: BGP communities to be associated with the given
+                        advertisement.
                       items:
                         type: string
                       type: array
@@ -224,7 +230,8 @@ spec:
   - name: v1beta1
     schema:
       openAPIV3Schema:
-        description: BFDProfile is the Schema for the bfdprofiles API.
+        description: BFDProfile represents the settings of the bfd session that can
+          be optionally associated with a BGP session.
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -242,30 +249,48 @@ spec:
             description: BFDProfileSpec defines the desired state of BFDProfile.
             properties:
               detectMultiplier:
+                description: Configures the detection multiplier to determine packet
+                  loss. The remote transmission interval will be multiplied by this
+                  value to determine the connection loss detection timer.
                 format: int32
                 maximum: 255
                 minimum: 2
                 type: integer
               echoInterval:
+                description: Configures the minimal echo receive transmission interval
+                  that this system is capable of handling in milliseconds. Defaults
+                  to 50ms
                 format: int32
                 maximum: 60000
                 minimum: 10
                 type: integer
               echoMode:
+                description: Enables or disables the echo transmission mode. This
+                  mode is disabled by default, and not supported on multi hops setups.
                 type: boolean
               minimumTtl:
+                description: 'For multi hop sessions only: configure the minimum expected
+                  TTL for an incoming BFD control packet.'
                 format: int32
                 maximum: 254
                 minimum: 1
                 type: integer
               passiveMode:
+                description: 'Mark session as passive: a passive session will not
+                  attempt to start the connection and will wait for control packets
+                  from peer before it begins replying.'
                 type: boolean
               receiveInterval:
+                description: The minimum interval that this system is capable of receiving
+                  control packets in milliseconds. Defaults to 300ms.
                 format: int32
                 maximum: 60000
                 minimum: 10
                 type: integer
               transmitInterval:
+                description: The minimum transmission interval (less jitter) that
+                  this system wants to use to send BFD control packets in milliseconds.
+                  Defaults to 300ms
                 format: int32
                 maximum: 60000
                 minimum: 10
@@ -305,7 +330,8 @@ spec:
   - name: v1beta1
     schema:
       openAPIV3Schema:
-        description: BGPAdvertisement is the Schema for the bgpadvertisements API.
+        description: BGPAdvertisement allows to advertise the IPs coming from the
+          selected IPAddressPools via BGP, setting the parameters of the BGP Advertisement.
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -325,24 +351,29 @@ spec:
               aggregationLength:
                 default: 32
                 description: The aggregation-length advertisement option lets you
-                  “roll up” the /32s into a larger prefix.
+                  “roll up” the /32s into a larger prefix. Defaults to 32. Works for
+                  IPv4 addresses.
                 format: int32
                 minimum: 1
                 type: integer
               aggregationLengthV6:
                 default: 128
-                description: Optional, defaults to 128 (i.e. no aggregation) if not
-                  specified.
+                description: The aggregation-length advertisement option lets you
+                  “roll up” the /128s into a larger prefix. Defaults to 128. Works
+                  for IPv6 addresses.
                 format: int32
                 type: integer
               communities:
-                description: BGP communities
+                description: The BGP communities to be associated with the announcement.
+                  Each item can be a community of the form 1234:1234 or the name of
+                  an alias defined in the Community CRD.
                 items:
                   type: string
                 type: array
               ipAddressPoolSelectors:
-                description: IPAddressPoolSelectors is a selector for the ipaddresspools
-                  which would get advertised via this advertisement.
+                description: A selector for the IPAddressPools which would get advertised
+                  via this advertisement. If no IPAddressPool is selected by this
+                  or by the list, the advertisement is applied to all the IPAddressPools.
                 items:
                   description: A label selector is a label query over a set of resources.
                     The result of matchLabels and matchExpressions are ANDed. An empty
@@ -392,20 +423,21 @@ spec:
                   type: object
                 type: array
               ipAddressPools:
-                description: IPAddressPools is the list of ipaddresspools to advertise
-                  via this advertisement.
+                description: The list of IPAddressPools to advertise via this advertisement,
+                  selected by name.
                 items:
                   type: string
                 type: array
               localPref:
-                description: BGP LOCAL_PREF attribute which is used by BGP best path
-                  algorithm, Path with higher localpref is preferred over one with
-                  lower localpref.
+                description: The BGP LOCAL_PREF attribute which is used by BGP best
+                  path algorithm, Path with higher localpref is preferred over one
+                  with lower localpref.
                 format: int32
                 type: integer
               nodeSelectors:
-                description: NodeSelectors is a selector on the node we should perform
-                  this advertisement from.
+                description: NodeSelectors allows to limit the nodes to announce as
+                  next hops for the LoadBalancer IP. When empty, all the nodes having  are
+                  announced as next hops.
                 items:
                   description: A label selector is a label query over a set of resources.
                     The result of matchLabels and matchExpressions are ANDed. An empty
@@ -455,8 +487,9 @@ spec:
                   type: object
                 type: array
               peers:
-                description: Peers are used to declare the intent of announcing the
-                  IPs of IPPools only to the Peers in this list.
+                description: Peers limits the bgppeer to advertise the ips of the
+                  selected pools to. When empty, the loadbalancer IP is announced
+                  to all the BGPPeers configured.
                 items:
                   type: string
                 type: array
@@ -616,9 +649,13 @@ spec:
             description: BGPPeerSpec defines the desired state of Peer.
             properties:
               bfdProfile:
+                description: The name of the BFD Profile to be used for the BFD session
+                  associated to the BGP session. If not set, the BFD session won't
+                  be set up.
                 type: string
               ebgpMultiHop:
-                description: EBGP peer is multi-hops away
+                description: To set if the BGPPeer is multi-hops away. Needed for
+                  FRR mode only.
                 type: boolean
               holdTime:
                 description: Requested BGP hold time, per RFC4271.
@@ -711,6 +748,7 @@ spec:
                 type: string
               peerPort:
                 default: 179
+                description: Port to dial when establishing the session.
                 maximum: 16384
                 minimum: 0
                 type: integer
@@ -759,7 +797,8 @@ spec:
   - name: v1beta1
     schema:
       openAPIV3Schema:
-        description: Community is the Schema for the communities API.
+        description: Community is a collection of aliases for communities. Users can
+          define named aliases to be used in the BGPPeer CRD.
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -780,10 +819,11 @@ spec:
                 items:
                   properties:
                     name:
-                      description: Name or identifier for the community.
+                      description: The name of the alias for the community.
                       type: string
                     value:
-                      description: BGP community value.
+                      description: The BGP community value corresponding to the given
+                        name.
                       type: string
                   type: object
                 type: array
@@ -822,7 +862,8 @@ spec:
   - name: v1beta1
     schema:
       openAPIV3Schema:
-        description: IPAddressPool is the Schema for the IPAddressPools API.
+        description: IPAddressPool represents a pool of IP addresses that can be allocated
+          to LoadBalancer services.
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -896,7 +937,8 @@ spec:
   - name: v1beta1
     schema:
       openAPIV3Schema:
-        description: L2Advertisement is the Schema for the l2advertisements API.
+        description: L2Advertisement allows to advertise the LoadBalancer IPs provided
+          by the selected pools via L2.
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -914,8 +956,9 @@ spec:
             description: L2AdvertisementSpec defines the desired state of L2Advertisement.
             properties:
               ipAddressPoolSelectors:
-                description: IPAddressPoolSelectors is a selector for the ipaddresspools
-                  which would get advertised via this advertisement.
+                description: A selector for the IPAddressPools which would get advertised
+                  via this advertisement. If no IPAddressPool is selected by this
+                  or by the list, the advertisement is applied to all the IPAddressPools.
                 items:
                   description: A label selector is a label query over a set of resources.
                     The result of matchLabels and matchExpressions are ANDed. An empty
@@ -965,14 +1008,15 @@ spec:
                   type: object
                 type: array
               ipAddressPools:
-                description: IPAddressPools is the list of ipaddresspools to advertise
-                  via this advertisement.
+                description: The list of IPAddressPools to advertise via this advertisement,
+                  selected by name.
                 items:
                   type: string
                 type: array
               nodeSelectors:
-                description: NodeSelectors is a selector on the node we should perform
-                  this advertisement from.
+                description: NodeSelectors allows to limit the nodes to announce as
+                  next hops for the LoadBalancer IP. When empty, all the nodes having  are
+                  announced as next hops.
                 items:
                   description: A label selector is a label query over a set of resources.
                     The result of matchLabels and matchExpressions are ANDed. An empty

--- a/bindata/deployment/frr-with-webhooks/metallb-frr-with-webhooks.yaml
+++ b/bindata/deployment/frr-with-webhooks/metallb-frr-with-webhooks.yaml
@@ -398,8 +398,6 @@ spec:
               value: /etc/frr_reloader/reloader.pid
             - name: METALLB_BGP_TYPE
               value: frr
-            # - name: FRR_LOGGING_LEVEL
-            #   value: informational
             - name: METALLB_NODE_NAME
               valueFrom:
                 fieldRef:

--- a/bindata/deployment/frr/metallb-frr.yaml
+++ b/bindata/deployment/frr/metallb-frr.yaml
@@ -374,8 +374,6 @@ spec:
               value: /etc/frr_reloader/reloader.pid
             - name: METALLB_BGP_TYPE
               value: frr
-            # - name: FRR_LOGGING_LEVEL
-            #   value: informational
             - name: METALLB_NODE_NAME
               valueFrom:
                 fieldRef:

--- a/bindata/deployment/openshift/metallb-openshift.yaml
+++ b/bindata/deployment/openshift/metallb-openshift.yaml
@@ -400,8 +400,6 @@ spec:
               value: /etc/frr_reloader/reloader.pid
             - name: METALLB_BGP_TYPE
               value: frr
-            # - name: FRR_LOGGING_LEVEL
-            #   value: informational
             - name: METALLB_NODE_NAME
               valueFrom:
                 fieldRef:

--- a/bundle/manifests/metallb.io_addresspools.yaml
+++ b/bundle/manifests/metallb.io_addresspools.yaml
@@ -101,10 +101,15 @@ spec:
     storage: false
     subresources:
       status: {}
-  - name: v1beta1
+  - deprecated: true
+    deprecationWarning: metallbio.io v1beta1 AddressPool is deprecated, consider using
+      IPAddressPool
+    name: v1beta1
     schema:
       openAPIV3Schema:
-        description: AddressPool is the Schema for the addresspools API.
+        description: AddressPool represents a pool of IP addresses that can be allocated
+          to LoadBalancer services. AddressPool is deprecated and being replaced by
+          IPAddressPool.
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -140,8 +145,8 @@ spec:
                   to be used by a pool.
                 type: boolean
               bgpAdvertisements:
-                description: When an IP is allocated from this pool, how should it
-                  be translated into BGP announcements?
+                description: Drives how an IP allocated from this pool should translated
+                  into BGP announcements.
                 items:
                   properties:
                     aggregationLength:
@@ -158,7 +163,8 @@ spec:
                       format: int32
                       type: integer
                     communities:
-                      description: BGP communities
+                      description: BGP communities to be associated with the given
+                        advertisement.
                       items:
                         type: string
                       type: array

--- a/bundle/manifests/metallb.io_bfdprofiles.yaml
+++ b/bundle/manifests/metallb.io_bfdprofiles.yaml
@@ -17,7 +17,8 @@ spec:
   - name: v1beta1
     schema:
       openAPIV3Schema:
-        description: BFDProfile is the Schema for the bfdprofiles API.
+        description: BFDProfile represents the settings of the bfd session that can
+          be optionally associated with a BGP session.
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -35,30 +36,48 @@ spec:
             description: BFDProfileSpec defines the desired state of BFDProfile.
             properties:
               detectMultiplier:
+                description: Configures the detection multiplier to determine packet
+                  loss. The remote transmission interval will be multiplied by this
+                  value to determine the connection loss detection timer.
                 format: int32
                 maximum: 255
                 minimum: 2
                 type: integer
               echoInterval:
+                description: Configures the minimal echo receive transmission interval
+                  that this system is capable of handling in milliseconds. Defaults
+                  to 50ms
                 format: int32
                 maximum: 60000
                 minimum: 10
                 type: integer
               echoMode:
+                description: Enables or disables the echo transmission mode. This
+                  mode is disabled by default, and not supported on multi hops setups.
                 type: boolean
               minimumTtl:
+                description: 'For multi hop sessions only: configure the minimum expected
+                  TTL for an incoming BFD control packet.'
                 format: int32
                 maximum: 254
                 minimum: 1
                 type: integer
               passiveMode:
+                description: 'Mark session as passive: a passive session will not
+                  attempt to start the connection and will wait for control packets
+                  from peer before it begins replying.'
                 type: boolean
               receiveInterval:
+                description: The minimum interval that this system is capable of receiving
+                  control packets in milliseconds. Defaults to 300ms.
                 format: int32
                 maximum: 60000
                 minimum: 10
                 type: integer
               transmitInterval:
+                description: The minimum transmission interval (less jitter) that
+                  this system wants to use to send BFD control packets in milliseconds.
+                  Defaults to 300ms
                 format: int32
                 maximum: 60000
                 minimum: 10

--- a/bundle/manifests/metallb.io_bgpadvertisements.yaml
+++ b/bundle/manifests/metallb.io_bgpadvertisements.yaml
@@ -17,7 +17,8 @@ spec:
   - name: v1beta1
     schema:
       openAPIV3Schema:
-        description: BGPAdvertisement is the Schema for the bgpadvertisements API.
+        description: BGPAdvertisement allows to advertise the IPs coming from the
+          selected IPAddressPools via BGP, setting the parameters of the BGP Advertisement.
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -37,24 +38,29 @@ spec:
               aggregationLength:
                 default: 32
                 description: The aggregation-length advertisement option lets you
-                  “roll up” the /32s into a larger prefix.
+                  “roll up” the /32s into a larger prefix. Defaults to 32. Works for
+                  IPv4 addresses.
                 format: int32
                 minimum: 1
                 type: integer
               aggregationLengthV6:
                 default: 128
-                description: Optional, defaults to 128 (i.e. no aggregation) if not
-                  specified.
+                description: The aggregation-length advertisement option lets you
+                  “roll up” the /128s into a larger prefix. Defaults to 128. Works
+                  for IPv6 addresses.
                 format: int32
                 type: integer
               communities:
-                description: BGP communities
+                description: The BGP communities to be associated with the announcement.
+                  Each item can be a community of the form 1234:1234 or the name of
+                  an alias defined in the Community CRD.
                 items:
                   type: string
                 type: array
               ipAddressPoolSelectors:
-                description: IPAddressPoolSelectors is a selector for the ipaddresspools
-                  which would get advertised via this advertisement.
+                description: A selector for the IPAddressPools which would get advertised
+                  via this advertisement. If no IPAddressPool is selected by this
+                  or by the list, the advertisement is applied to all the IPAddressPools.
                 items:
                   description: A label selector is a label query over a set of resources.
                     The result of matchLabels and matchExpressions are ANDed. An empty
@@ -104,20 +110,21 @@ spec:
                   type: object
                 type: array
               ipAddressPools:
-                description: IPAddressPools is the list of ipaddresspools to advertise
-                  via this advertisement.
+                description: The list of IPAddressPools to advertise via this advertisement,
+                  selected by name.
                 items:
                   type: string
                 type: array
               localPref:
-                description: BGP LOCAL_PREF attribute which is used by BGP best path
-                  algorithm, Path with higher localpref is preferred over one with
-                  lower localpref.
+                description: The BGP LOCAL_PREF attribute which is used by BGP best
+                  path algorithm, Path with higher localpref is preferred over one
+                  with lower localpref.
                 format: int32
                 type: integer
               nodeSelectors:
-                description: NodeSelectors is a selector on the node we should perform
-                  this advertisement from.
+                description: NodeSelectors allows to limit the nodes to announce as
+                  next hops for the LoadBalancer IP. When empty, all the nodes having  are
+                  announced as next hops.
                 items:
                   description: A label selector is a label query over a set of resources.
                     The result of matchLabels and matchExpressions are ANDed. An empty
@@ -167,8 +174,9 @@ spec:
                   type: object
                 type: array
               peers:
-                description: Peers are used to declare the intent of announcing the
-                  IPs of IPPools only to the Peers in this list.
+                description: Peers limits the bgppeer to advertise the ips of the
+                  selected pools to. When empty, the loadbalancer IP is announced
+                  to all the BGPPeers configured.
                 items:
                   type: string
                 type: array

--- a/bundle/manifests/metallb.io_bgppeers.yaml
+++ b/bundle/manifests/metallb.io_bgppeers.yaml
@@ -138,9 +138,13 @@ spec:
             description: BGPPeerSpec defines the desired state of Peer.
             properties:
               bfdProfile:
+                description: The name of the BFD Profile to be used for the BFD session
+                  associated to the BGP session. If not set, the BFD session won't
+                  be set up.
                 type: string
               ebgpMultiHop:
-                description: EBGP peer is multi-hops away
+                description: To set if the BGPPeer is multi-hops away. Needed for
+                  FRR mode only.
                 type: boolean
               holdTime:
                 description: Requested BGP hold time, per RFC4271.
@@ -233,6 +237,7 @@ spec:
                 type: string
               peerPort:
                 default: 179
+                description: Port to dial when establishing the session.
                 maximum: 16384
                 minimum: 0
                 type: integer

--- a/bundle/manifests/metallb.io_communities.yaml
+++ b/bundle/manifests/metallb.io_communities.yaml
@@ -17,7 +17,8 @@ spec:
   - name: v1beta1
     schema:
       openAPIV3Schema:
-        description: Community is the Schema for the communities API.
+        description: Community is a collection of aliases for communities. Users can
+          define named aliases to be used in the BGPPeer CRD.
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -38,10 +39,11 @@ spec:
                 items:
                   properties:
                     name:
-                      description: Name or identifier for the community.
+                      description: The name of the alias for the community.
                       type: string
                     value:
-                      description: BGP community value.
+                      description: The BGP community value corresponding to the given
+                        name.
                       type: string
                   type: object
                 type: array

--- a/bundle/manifests/metallb.io_ipaddresspools.yaml
+++ b/bundle/manifests/metallb.io_ipaddresspools.yaml
@@ -17,7 +17,8 @@ spec:
   - name: v1beta1
     schema:
       openAPIV3Schema:
-        description: IPAddressPool is the Schema for the IPAddressPools API.
+        description: IPAddressPool represents a pool of IP addresses that can be allocated
+          to LoadBalancer services.
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation

--- a/bundle/manifests/metallb.io_l2advertisements.yaml
+++ b/bundle/manifests/metallb.io_l2advertisements.yaml
@@ -17,7 +17,8 @@ spec:
   - name: v1beta1
     schema:
       openAPIV3Schema:
-        description: L2Advertisement is the Schema for the l2advertisements API.
+        description: L2Advertisement allows to advertise the LoadBalancer IPs provided
+          by the selected pools via L2.
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -35,8 +36,9 @@ spec:
             description: L2AdvertisementSpec defines the desired state of L2Advertisement.
             properties:
               ipAddressPoolSelectors:
-                description: IPAddressPoolSelectors is a selector for the ipaddresspools
-                  which would get advertised via this advertisement.
+                description: A selector for the IPAddressPools which would get advertised
+                  via this advertisement. If no IPAddressPool is selected by this
+                  or by the list, the advertisement is applied to all the IPAddressPools.
                 items:
                   description: A label selector is a label query over a set of resources.
                     The result of matchLabels and matchExpressions are ANDed. An empty
@@ -86,14 +88,15 @@ spec:
                   type: object
                 type: array
               ipAddressPools:
-                description: IPAddressPools is the list of ipaddresspools to advertise
-                  via this advertisement.
+                description: The list of IPAddressPools to advertise via this advertisement,
+                  selected by name.
                 items:
                   type: string
                 type: array
               nodeSelectors:
-                description: NodeSelectors is a selector on the node we should perform
-                  this advertisement from.
+                description: NodeSelectors allows to limit the nodes to announce as
+                  next hops for the LoadBalancer IP. When empty, all the nodes having  are
+                  announced as next hops.
                 items:
                   description: A label selector is a label query over a set of resources.
                     The result of matchLabels and matchExpressions are ANDed. An empty

--- a/config/crd/bases/metallb.io_addresspools.yaml
+++ b/config/crd/bases/metallb.io_addresspools.yaml
@@ -101,10 +101,15 @@ spec:
     storage: false
     subresources:
       status: {}
-  - name: v1beta1
+  - deprecated: true
+    deprecationWarning: metallbio.io v1beta1 AddressPool is deprecated, consider using
+      IPAddressPool
+    name: v1beta1
     schema:
       openAPIV3Schema:
-        description: AddressPool is the Schema for the addresspools API.
+        description: AddressPool represents a pool of IP addresses that can be allocated
+          to LoadBalancer services. AddressPool is deprecated and being replaced by
+          IPAddressPool.
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -140,8 +145,8 @@ spec:
                   to be used by a pool.
                 type: boolean
               bgpAdvertisements:
-                description: When an IP is allocated from this pool, how should it
-                  be translated into BGP announcements?
+                description: Drives how an IP allocated from this pool should translated
+                  into BGP announcements.
                 items:
                   properties:
                     aggregationLength:
@@ -158,7 +163,8 @@ spec:
                       format: int32
                       type: integer
                     communities:
-                      description: BGP communities
+                      description: BGP communities to be associated with the given
+                        advertisement.
                       items:
                         type: string
                       type: array

--- a/config/crd/bases/metallb.io_bfdprofiles.yaml
+++ b/config/crd/bases/metallb.io_bfdprofiles.yaml
@@ -17,7 +17,8 @@ spec:
   - name: v1beta1
     schema:
       openAPIV3Schema:
-        description: BFDProfile is the Schema for the bfdprofiles API.
+        description: BFDProfile represents the settings of the bfd session that can
+          be optionally associated with a BGP session.
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -35,30 +36,48 @@ spec:
             description: BFDProfileSpec defines the desired state of BFDProfile.
             properties:
               detectMultiplier:
+                description: Configures the detection multiplier to determine packet
+                  loss. The remote transmission interval will be multiplied by this
+                  value to determine the connection loss detection timer.
                 format: int32
                 maximum: 255
                 minimum: 2
                 type: integer
               echoInterval:
+                description: Configures the minimal echo receive transmission interval
+                  that this system is capable of handling in milliseconds. Defaults
+                  to 50ms
                 format: int32
                 maximum: 60000
                 minimum: 10
                 type: integer
               echoMode:
+                description: Enables or disables the echo transmission mode. This
+                  mode is disabled by default, and not supported on multi hops setups.
                 type: boolean
               minimumTtl:
+                description: 'For multi hop sessions only: configure the minimum expected
+                  TTL for an incoming BFD control packet.'
                 format: int32
                 maximum: 254
                 minimum: 1
                 type: integer
               passiveMode:
+                description: 'Mark session as passive: a passive session will not
+                  attempt to start the connection and will wait for control packets
+                  from peer before it begins replying.'
                 type: boolean
               receiveInterval:
+                description: The minimum interval that this system is capable of receiving
+                  control packets in milliseconds. Defaults to 300ms.
                 format: int32
                 maximum: 60000
                 minimum: 10
                 type: integer
               transmitInterval:
+                description: The minimum transmission interval (less jitter) that
+                  this system wants to use to send BFD control packets in milliseconds.
+                  Defaults to 300ms
                 format: int32
                 maximum: 60000
                 minimum: 10

--- a/config/crd/bases/metallb.io_bgpadvertisements.yaml
+++ b/config/crd/bases/metallb.io_bgpadvertisements.yaml
@@ -17,7 +17,8 @@ spec:
   - name: v1beta1
     schema:
       openAPIV3Schema:
-        description: BGPAdvertisement is the Schema for the bgpadvertisements API.
+        description: BGPAdvertisement allows to advertise the IPs coming from the
+          selected IPAddressPools via BGP, setting the parameters of the BGP Advertisement.
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -37,24 +38,29 @@ spec:
               aggregationLength:
                 default: 32
                 description: The aggregation-length advertisement option lets you
-                  “roll up” the /32s into a larger prefix.
+                  “roll up” the /32s into a larger prefix. Defaults to 32. Works for
+                  IPv4 addresses.
                 format: int32
                 minimum: 1
                 type: integer
               aggregationLengthV6:
                 default: 128
-                description: Optional, defaults to 128 (i.e. no aggregation) if not
-                  specified.
+                description: The aggregation-length advertisement option lets you
+                  “roll up” the /128s into a larger prefix. Defaults to 128. Works
+                  for IPv6 addresses.
                 format: int32
                 type: integer
               communities:
-                description: BGP communities
+                description: The BGP communities to be associated with the announcement.
+                  Each item can be a community of the form 1234:1234 or the name of
+                  an alias defined in the Community CRD.
                 items:
                   type: string
                 type: array
               ipAddressPoolSelectors:
-                description: IPAddressPoolSelectors is a selector for the ipaddresspools
-                  which would get advertised via this advertisement.
+                description: A selector for the IPAddressPools which would get advertised
+                  via this advertisement. If no IPAddressPool is selected by this
+                  or by the list, the advertisement is applied to all the IPAddressPools.
                 items:
                   description: A label selector is a label query over a set of resources.
                     The result of matchLabels and matchExpressions are ANDed. An empty
@@ -104,20 +110,21 @@ spec:
                   type: object
                 type: array
               ipAddressPools:
-                description: IPAddressPools is the list of ipaddresspools to advertise
-                  via this advertisement.
+                description: The list of IPAddressPools to advertise via this advertisement,
+                  selected by name.
                 items:
                   type: string
                 type: array
               localPref:
-                description: BGP LOCAL_PREF attribute which is used by BGP best path
-                  algorithm, Path with higher localpref is preferred over one with
-                  lower localpref.
+                description: The BGP LOCAL_PREF attribute which is used by BGP best
+                  path algorithm, Path with higher localpref is preferred over one
+                  with lower localpref.
                 format: int32
                 type: integer
               nodeSelectors:
-                description: NodeSelectors is a selector on the node we should perform
-                  this advertisement from.
+                description: NodeSelectors allows to limit the nodes to announce as
+                  next hops for the LoadBalancer IP. When empty, all the nodes having  are
+                  announced as next hops.
                 items:
                   description: A label selector is a label query over a set of resources.
                     The result of matchLabels and matchExpressions are ANDed. An empty
@@ -167,8 +174,9 @@ spec:
                   type: object
                 type: array
               peers:
-                description: Peers are used to declare the intent of announcing the
-                  IPs of IPPools only to the Peers in this list.
+                description: Peers limits the bgppeer to advertise the ips of the
+                  selected pools to. When empty, the loadbalancer IP is announced
+                  to all the BGPPeers configured.
                 items:
                   type: string
                 type: array

--- a/config/crd/bases/metallb.io_bgppeers.yaml
+++ b/config/crd/bases/metallb.io_bgppeers.yaml
@@ -138,9 +138,13 @@ spec:
             description: BGPPeerSpec defines the desired state of Peer.
             properties:
               bfdProfile:
+                description: The name of the BFD Profile to be used for the BFD session
+                  associated to the BGP session. If not set, the BFD session won't
+                  be set up.
                 type: string
               ebgpMultiHop:
-                description: EBGP peer is multi-hops away
+                description: To set if the BGPPeer is multi-hops away. Needed for
+                  FRR mode only.
                 type: boolean
               holdTime:
                 description: Requested BGP hold time, per RFC4271.
@@ -233,6 +237,7 @@ spec:
                 type: string
               peerPort:
                 default: 179
+                description: Port to dial when establishing the session.
                 maximum: 16384
                 minimum: 0
                 type: integer

--- a/config/crd/bases/metallb.io_communities.yaml
+++ b/config/crd/bases/metallb.io_communities.yaml
@@ -17,7 +17,8 @@ spec:
   - name: v1beta1
     schema:
       openAPIV3Schema:
-        description: Community is the Schema for the communities API.
+        description: Community is a collection of aliases for communities. Users can
+          define named aliases to be used in the BGPPeer CRD.
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -38,10 +39,11 @@ spec:
                 items:
                   properties:
                     name:
-                      description: Name or identifier for the community.
+                      description: The name of the alias for the community.
                       type: string
                     value:
-                      description: BGP community value.
+                      description: The BGP community value corresponding to the given
+                        name.
                       type: string
                   type: object
                 type: array

--- a/config/crd/bases/metallb.io_ipaddresspools.yaml
+++ b/config/crd/bases/metallb.io_ipaddresspools.yaml
@@ -17,7 +17,8 @@ spec:
   - name: v1beta1
     schema:
       openAPIV3Schema:
-        description: IPAddressPool is the Schema for the IPAddressPools API.
+        description: IPAddressPool represents a pool of IP addresses that can be allocated
+          to LoadBalancer services.
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation

--- a/config/crd/bases/metallb.io_l2advertisements.yaml
+++ b/config/crd/bases/metallb.io_l2advertisements.yaml
@@ -17,7 +17,8 @@ spec:
   - name: v1beta1
     schema:
       openAPIV3Schema:
-        description: L2Advertisement is the Schema for the l2advertisements API.
+        description: L2Advertisement allows to advertise the LoadBalancer IPs provided
+          by the selected pools via L2.
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -35,8 +36,9 @@ spec:
             description: L2AdvertisementSpec defines the desired state of L2Advertisement.
             properties:
               ipAddressPoolSelectors:
-                description: IPAddressPoolSelectors is a selector for the ipaddresspools
-                  which would get advertised via this advertisement.
+                description: A selector for the IPAddressPools which would get advertised
+                  via this advertisement. If no IPAddressPool is selected by this
+                  or by the list, the advertisement is applied to all the IPAddressPools.
                 items:
                   description: A label selector is a label query over a set of resources.
                     The result of matchLabels and matchExpressions are ANDed. An empty
@@ -86,14 +88,15 @@ spec:
                   type: object
                 type: array
               ipAddressPools:
-                description: IPAddressPools is the list of ipaddresspools to advertise
-                  via this advertisement.
+                description: The list of IPAddressPools to advertise via this advertisement,
+                  selected by name.
                 items:
                   type: string
                 type: array
               nodeSelectors:
-                description: NodeSelectors is a selector on the node we should perform
-                  this advertisement from.
+                description: NodeSelectors allows to limit the nodes to announce as
+                  next hops for the LoadBalancer IP. When empty, all the nodes having  are
+                  announced as next hops.
                 items:
                   description: A label selector is a label query over a set of resources.
                     The result of matchLabels and matchExpressions are ANDed. An empty

--- a/hack/common.sh
+++ b/hack/common.sh
@@ -17,7 +17,7 @@ export PATH=$PATH:$GOPATH/bin
 
 mkdir -p _cache
 
-export METALLB_COMMIT_ID="9985a602b7c93a51dcce6c5d6f9bb4ec98760115"
+export METALLB_COMMIT_ID="25a037f08201eb9a88668805684d7cecb36cea44"
 export METALLB_PATH=_cache/metallb
 
 export METALLB_SC_FILE=$(dirname "$0")/securityContext.yaml


### PR DESCRIPTION
We want to ensure older versions of the CRDs are still working when
deploying the operator.
