### PR TITLE
Restore alm and demo examples for MetalLB CRDs

### DIFF
--- a/bundle/manifests/metallb-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/metallb-operator.clusterserviceversion.yaml
@@ -6,10 +6,266 @@ metadata:
       [
         {
           "apiVersion": "metallb.io/v1beta1",
+          "kind": "BFDProfile",
+          "metadata": {
+            "name": "bfd-profile-sample",
+            "namespace": "metallb-system"
+          },
+          "spec": {
+            "receiveInterval": 380,
+            "transmitInterval": 270
+          }
+        },
+        {
+          "apiVersion": "metallb.io/v1beta1",
+          "kind": "BGPAdvertisement",
+          "metadata": {
+            "name": "bgp-adv-sample1",
+            "namespace": "metallb-system"
+          },
+          "spec": {
+            "ipAddressPools": [
+              "ip-addresspool-sample1"
+            ],
+            "peers": [
+              "ebgp-single-hop0"
+            ]
+          }
+        },
+        {
+          "apiVersion": "metallb.io/v1beta1",
+          "kind": "BGPAdvertisement",
+          "metadata": {
+            "name": "bgp-adv-sample2",
+            "namespace": "metallb-system"
+          },
+          "spec": {
+            "ipAddressPoolSelectors": [
+              {
+                "matchLabels": {
+                  "test": "ipv6"
+                }
+              },
+              {
+                "matchLabels": {
+                  "test": "ipv4"
+                }
+              }
+            ]
+          }
+        },
+        {
+          "apiVersion": "metallb.io/v1beta1",
+          "kind": "BGPAdvertisement",
+          "metadata": {
+            "name": "bgp-adv-sample3",
+            "namespace": "metallb-system"
+          },
+          "spec": {
+            "aggregationLength": 32,
+            "aggregationLengthV6": 128,
+            "communities": [
+              "65535:65282"
+            ],
+            "ipAddressPools": [
+              "ip-addresspool-sample1"
+            ],
+            "localPref": 50
+          }
+        },
+        {
+          "apiVersion": "metallb.io/v1beta1",
+          "kind": "BGPAdvertisement",
+          "metadata": {
+            "name": "bgp-adv-sample4",
+            "namespace": "metallb-system"
+          },
+          "spec": {
+            "aggregationLength": 32,
+            "aggregationLengthV6": 128,
+            "communities": [
+              "NO_ADVERTISE"
+            ],
+            "ipAddressPools": [
+              "ip-addresspool-sample1"
+            ],
+            "localPref": 50
+          }
+        },
+        {
+          "apiVersion": "metallb.io/v1beta1",
+          "kind": "BGPAdvertisement",
+          "metadata": {
+            "name": "bgp-adv-sample5",
+            "namespace": "metallb-system"
+          },
+          "spec": {
+            "aggregationLength": 32,
+            "aggregationLengthV6": 128,
+            "ipAddressPools": [
+              "ip-addresspool-sample1"
+            ],
+            "nodeSelectors": [
+              {
+                "matchLabels": {
+                  "kubernetes.io/hostname": "kind-control-plane"
+                }
+              },
+              {
+                "matchLabels": {
+                  "kubernetes.io/hostname": "kind-worker"
+                }
+              }
+            ]
+          }
+        },
+        {
+          "apiVersion": "metallb.io/v1beta1",
+          "kind": "Community",
+          "metadata": {
+            "name": "community1",
+            "namespace": "metallb-system"
+          },
+          "spec": {
+            "communities": [
+              {
+                "name": "NO_ADVERTISE",
+                "value": "65535:65282"
+              }
+            ]
+          }
+        },
+        {
+          "apiVersion": "metallb.io/v1beta1",
+          "kind": "IPAddressPool",
+          "metadata": {
+            "name": "ip-addresspool-sample1",
+            "namespace": "metallb-system"
+          },
+          "spec": {
+            "addresses": [
+              "192.168.10.0/24",
+              "192.168.9.1-192.168.9.5",
+              "fc00:f853:0ccd:e799::/124"
+            ]
+          }
+        },
+        {
+          "apiVersion": "metallb.io/v1beta1",
+          "kind": "IPAddressPool",
+          "metadata": {
+            "labels": {
+              "test": "ipv4"
+            },
+            "name": "ip-addresspool-sample2",
+            "namespace": "metallb-system"
+          },
+          "spec": {
+            "addresses": [
+              "172.20.0.100/24"
+            ],
+            "autoAssign": false
+          }
+        },
+        {
+          "apiVersion": "metallb.io/v1beta1",
+          "kind": "IPAddressPool",
+          "metadata": {
+            "labels": {
+              "test": "ipv6"
+            },
+            "name": "ip-addresspool-sample3",
+            "namespace": "metallb-system"
+          },
+          "spec": {
+            "addresses": [
+              "2002:2:2::1-2002:2:2::100"
+            ]
+          }
+        },
+        {
+          "apiVersion": "metallb.io/v1beta1",
+          "kind": "L2Advertisement",
+          "metadata": {
+            "name": "l2-adv-sample1",
+            "namespace": "metallb-system"
+          },
+          "spec": {
+            "ipAddressPools": [
+              "ip-addresspool-sample1"
+            ]
+          }
+        },
+        {
+          "apiVersion": "metallb.io/v1beta1",
+          "kind": "L2Advertisement",
+          "metadata": {
+            "name": "l2-adv-sample2",
+            "namespace": "metallb-system"
+          },
+          "spec": {
+            "nodeSelectors": [
+              {
+                "matchLabels": {
+                  "kubernetes.io/hostname": "kind-control-plane"
+                }
+              }
+            ]
+          }
+        },
+        {
+          "apiVersion": "metallb.io/v1beta1",
           "kind": "MetalLB",
           "metadata": {
             "name": "metallb",
             "namespace": "metallb-system"
+          }
+        },
+        {
+          "apiVersion": "metallb.io/v1beta2",
+          "kind": "BGPPeer",
+          "metadata": {
+            "name": "bgp-peer-sample1",
+            "namespace": "metallb-system"
+          },
+          "spec": {
+            "myASN": 64512,
+            "peerASN": 64512,
+            "peerAddress": "172.30.0.3"
+          }
+        },
+        {
+          "apiVersion": "metallb.io/v1beta2",
+          "kind": "BGPPeer",
+          "metadata": {
+            "name": "bgp-peer-sample2",
+            "namespace": "metallb-system"
+          },
+          "spec": {
+            "bfdProfile": "bfd-profile-sample",
+            "myASN": 64512,
+            "peerASN": 64512,
+            "peerAddress": "172.30.0.3"
+          }
+        },
+        {
+          "apiVersion": "metallb.io/v1beta2",
+          "kind": "BGPPeer",
+          "metadata": {
+            "name": "bgp-peer-sample3",
+            "namespace": "metallb-system"
+          },
+          "spec": {
+            "holdTime": "9m0s",
+            "keepaliveTime": "0s",
+            "myASN": 64512,
+            "passwordSecret": {
+              "name": "secretname",
+              "namespace": "metallb-system"
+            },
+            "peerASN": 64512,
+            "peerAddress": "172.30.0.3",
+            "peerPort": 180
           }
         }
       ]

--- a/config/samples/kustomization.yaml
+++ b/config/samples/kustomization.yaml
@@ -1,4 +1,9 @@
 ## Append samples you want in your CSV to this file as resources ##
 resources:
 - metallb.yaml
+- metallb.io_v1beta1_bfdprofile.yaml
+- metallb.io_v1beta2_bgppeer.yaml
+- metallb.io_v1beta1_ipaddresspool.yaml
+- metallb_v1beta1_bgpadvertisement.yaml
+- metallb_v1beta1_l2advertisement.yaml
 #+kubebuilder:scaffold:manifestskustomizesamples

--- a/config/samples/metallb.io_v1beta1_bfdprofile.yaml
+++ b/config/samples/metallb.io_v1beta1_bfdprofile.yaml
@@ -1,0 +1,8 @@
+apiVersion: metallb.io/v1beta1
+kind: BFDProfile
+metadata:
+  name: bfd-profile-sample
+  namespace: metallb-system
+spec:
+  receiveInterval: 380
+  transmitInterval: 270

--- a/config/samples/metallb.io_v1beta1_ipaddresspool.yaml
+++ b/config/samples/metallb.io_v1beta1_ipaddresspool.yaml
@@ -1,0 +1,33 @@
+apiVersion: metallb.io/v1beta1
+kind: IPAddressPool
+metadata:
+  name: ip-addresspool-sample1
+  namespace: metallb-system
+spec:
+  addresses:
+  - 192.168.10.0/24
+  - 192.168.9.1-192.168.9.5
+  - fc00:f853:0ccd:e799::/124
+---
+apiVersion: metallb.io/v1beta1
+kind: IPAddressPool
+metadata:
+  name: ip-addresspool-sample2
+  namespace: metallb-system
+  labels:
+    test: ipv4
+spec:
+  addresses:
+    - 172.20.0.100/24
+  autoAssign: false
+---
+apiVersion: metallb.io/v1beta1
+kind: IPAddressPool
+metadata:
+  name: ip-addresspool-sample3
+  namespace: metallb-system
+  labels:
+    test: ipv6
+spec:
+  addresses:
+    - 2002:2:2::1-2002:2:2::100

--- a/config/samples/metallb.io_v1beta2_bgppeer.yaml
+++ b/config/samples/metallb.io_v1beta2_bgppeer.yaml
@@ -1,0 +1,36 @@
+apiVersion: metallb.io/v1beta2
+kind: BGPPeer
+metadata:
+  name: bgp-peer-sample1
+  namespace: metallb-system
+spec:
+  myASN: 64512
+  peerASN: 64512
+  peerAddress: 172.30.0.3
+---
+apiVersion: metallb.io/v1beta2
+kind: BGPPeer
+metadata:
+  name: bgp-peer-sample2
+  namespace: metallb-system
+spec:
+  myASN: 64512
+  peerASN: 64512
+  peerAddress: 172.30.0.3
+  bfdProfile: bfd-profile-sample
+---
+apiVersion: metallb.io/v1beta2
+kind: BGPPeer
+metadata:
+  name: bgp-peer-sample3
+  namespace: metallb-system
+spec:
+  holdTime: 9m0s
+  keepaliveTime: 0s
+  myASN: 64512
+  passwordSecret:
+    name: secretname
+    namespace: metallb-system
+  peerASN: 64512
+  peerAddress: 172.30.0.3
+  peerPort: 180

--- a/config/samples/metallb_v1beta1_bgpadvertisement.yaml
+++ b/config/samples/metallb_v1beta1_bgpadvertisement.yaml
@@ -1,0 +1,76 @@
+apiVersion: metallb.io/v1beta1
+kind: BGPAdvertisement
+metadata:
+  name: bgp-adv-sample1
+  namespace: metallb-system
+spec:
+  ipAddressPools:
+  - ip-addresspool-sample1
+  peers:
+  - ebgp-single-hop0
+---
+apiVersion: metallb.io/v1beta1
+kind: BGPAdvertisement
+metadata:
+  name: bgp-adv-sample2
+  namespace: metallb-system
+spec:
+  ipAddressPoolSelectors:
+  - matchLabels:
+      test: ipv6
+  - matchLabels:
+      test: ipv4
+---
+apiVersion: metallb.io/v1beta1
+kind: BGPAdvertisement
+metadata:
+  name: bgp-adv-sample3
+  namespace: metallb-system
+spec:
+  aggregationLength: 32
+  aggregationLengthV6: 128
+  communities:
+  - 65535:65282
+  ipAddressPools:
+  - ip-addresspool-sample1
+  localPref: 50
+---
+apiVersion: metallb.io/v1beta1
+kind: BGPAdvertisement
+metadata:
+  namespace: metallb-system
+  name: bgp-adv-sample4
+spec:
+  aggregationLength: 32
+  aggregationLengthV6: 128
+  communities:
+  - NO_ADVERTISE
+  ipAddressPools:
+  - ip-addresspool-sample1
+  localPref: 50
+---
+apiVersion: metallb.io/v1beta1
+kind: Community
+metadata:
+  name: community1
+  namespace: metallb-system
+spec:
+  communities:
+  - name: NO_ADVERTISE
+    value: 65535:65282
+---
+apiVersion: metallb.io/v1beta1
+kind: BGPAdvertisement
+metadata:
+  name: bgp-adv-sample5
+  namespace: metallb-system
+spec:
+  aggregationLength: 32
+  aggregationLengthV6: 128
+  ipAddressPools:
+  - ip-addresspool-sample1
+  nodeSelectors:
+  - matchLabels:
+      kubernetes.io/hostname: kind-control-plane
+  - matchLabels:
+      kubernetes.io/hostname: kind-worker

--- a/config/samples/metallb_v1beta1_l2advertisement.yaml
+++ b/config/samples/metallb_v1beta1_l2advertisement.yaml
@@ -1,0 +1,18 @@
+apiVersion: metallb.io/v1beta1
+kind: L2Advertisement
+metadata:
+  name: l2-adv-sample1
+  namespace: metallb-system
+spec:
+  ipAddressPools:
+    - ip-addresspool-sample1
+---
+apiVersion: metallb.io/v1beta1
+kind: L2Advertisement
+metadata:
+  name: l2-adv-sample2
+  namespace: metallb-system  
+spec:
+  nodeSelectors:
+  - matchLabels:
+      kubernetes.io/hostname: kind-control-plane


### PR DESCRIPTION
The alm examples annotation was inadvertently removed while migrating
CRDs, hence adding new versions of bfd profile, bgp peer, ip address
pool, bgp and l2 advertisement examples.

Signed-off-by: Periyasamy Palanisamy <pepalani@redhat.com>