### PR TITLE
Bump versions: bump also the manifests under bin

### DIFF
--- a/hack/bump_versions.sh
+++ b/hack/bump_versions.sh
@@ -21,3 +21,7 @@ yq e --inplace '.images[] |= select (.name == "controller") |= .newTag="'$operat
 yq e --inplace '. |= select (.kind == "CatalogSource") |= .spec.image="quay.io/metallb/metallb-operator-bundle-index:'$operator_version'"' config/olm-install/install-resources.yaml
 
 sed -E -i "s/VERSION \?= .*$/VERSION \?= $operator_version/g" Makefile
+
+sed -i "s/quay.io\/metallb\/speaker:main/quay.io\/metallb\/speaker:$metallb_version/g" bin/metallb-operator.yaml
+sed -i "s/quay.io\/metallb\/controller:main/quay.io\/metallb\/controller:$metallb_version/g" bin/metallb-operator.yaml
+sed -i "s/quay.io\/metallb\/metallb-operator:latest/quay.io\/metallb\/metallb-operator:$operator_version/g" bin/metallb-operator.yaml

--- a/hack/bump_versions.sh
+++ b/hack/bump_versions.sh
@@ -18,6 +18,10 @@ yq e --inplace '.spec.install.spec.deployments.[0].spec.template.spec.containers
 yq e --inplace '.spec.version |= "'$csv_version'"' bundle/manifests/metallb-operator.clusterserviceversion.yaml
 yq e --inplace '.images[] |= select (.name == "controller") |= .newTag="'$operator_version'"' config/manager/kustomization.yaml
 
+if [ "$operator_version" != "latest" ]; then
+sed -i "s/name: metallb-operator.v0.0.0/name: metallb-operator.v$operator_version/" bundle/manifests/metallb-operator.clusterserviceversion.yaml
+fi
+
 yq e --inplace '. |= select (.kind == "CatalogSource") |= .spec.image="quay.io/metallb/metallb-operator-bundle-index:'$operator_version'"' config/olm-install/install-resources.yaml
 
 sed -E -i "s/VERSION \?= .*$/VERSION \?= $operator_version/g" Makefile


### PR DESCRIPTION
When bumping versions, we must also take care of the manifests under bin
otherwise they'll reference main / latest.