### PR TITLE
CI: align to metallb improvements

### DIFF
--- a/.github/workflows/cancel.yaml
+++ b/.github/workflows/cancel.yaml
@@ -1,0 +1,13 @@
+name: Cancel
+on:
+  workflow_run:
+    workflows: ["CI"]
+    types:
+      - requested
+jobs:
+  cancel:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: styfle/cancel-workflow-action@0.9.1
+      with:
+        workflow_id: ${{ github.event.workflow.id }}

--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -19,6 +19,11 @@ jobs:
     name: Lint
     runs-on: ubuntu-20.04
     steps:
+    - name: Cancel Previous Runs
+      uses: styfle/cancel-workflow-action@0.9.1
+      with:
+        access_token: ${{ github.token }}
+
     - name: Check out code
       uses: actions/checkout@v2
 

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -49,7 +49,7 @@ jobs:
 
     - name: Build image
       run: |
-        docker build . -t ${built_image}
+        IMG=${built_image} make docker-build
 
     - name: Create K8s Kind Cluster
       run: |

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -23,6 +23,10 @@ jobs:
         go: [ '1.18.3' ]
     name: Go ${{ matrix.go }}
     steps:
+    - name: Cancel Previous Runs
+      uses: styfle/cancel-workflow-action@0.9.1
+      with:
+        access_token: ${{ github.token }}
     - name: Checkout Metal LB Operator
       uses: actions/checkout@v2
       with:

--- a/.github/workflows/metallb_e2e.yml
+++ b/.github/workflows/metallb_e2e.yml
@@ -59,7 +59,7 @@ jobs:
           sudo pip3 install -r ${GITHUB_WORKSPACE}/metallb/dev-env/requirements.txt
       - name: Build image
         run: |
-          docker build . -t ${built_image}
+          IMG=${built_image} make docker-build
       - name: Create multi-node K8s Kind Cluster
         run: |
           ./hack/kind-multi-node-cluster-without-registry.sh

--- a/.github/workflows/metallb_e2e.yml
+++ b/.github/workflows/metallb_e2e.yml
@@ -21,6 +21,10 @@ jobs:
         go: ["1.18.3"]
     name: Go ${{ matrix.go }}
     steps:
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.9.1
+        with:
+          access_token: ${{ github.token }}
       - name: Checkout Metal LB Operator
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/olm.yml
+++ b/.github/workflows/olm.yml
@@ -22,6 +22,10 @@ jobs:
         go: [ '1.18.3' ]
     name: Go ${{ matrix.go }}
     steps:
+    - name: Cancel Previous Runs
+      uses: styfle/cancel-workflow-action@0.9.1
+      with:
+        access_token: ${{ github.token }}
     - name: Checkout Metal LB Operator
       uses: actions/checkout@v2
       with:

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -99,7 +99,7 @@ jobs:
           username: ${{ secrets.QUAY_USER }}
           password: ${{ secrets.QUAY_PASSWORD }}
 
-      - name: Docker meta ${{ matrix.image }}
+      - name: Docker meta
         id: meta
         uses: docker/metadata-action@v4
         with:
@@ -119,7 +119,7 @@ jobs:
           context: .
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          file: ${{matrix.image}}/Dockerfile
+          file: ./Dockerfile
           platforms: linux/amd64,linux/arm64,linux/s390x,linux/ppc64le,linux/arm/v7
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,6 +3,9 @@ name: Release
 on:
   push:
     # Sequence of patterns matched against refs/tags
+    branches:
+      - "main"
+      - "v[0-9]+.[0-9]+"
     tags:
       - "v[0-9]+.[0-9]+.[0-9]+"
       - "v[0-9]+.[0-9]+"
@@ -76,9 +79,59 @@ jobs:
           name: kind_logs
           path: /tmp/kind_logs
 
-  release:
+  publish-image:
     needs: [main]
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Code checkout
+        uses: actions/checkout@v3
+
+      - name: Setup docker buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Log into Quay
+        uses: docker/login-action@v2
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_USER }}
+          password: ${{ secrets.QUAY_PASSWORD }}
+
+      - name: Docker meta ${{ matrix.image }}
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: |
+            quay.io/metallb/metallb-operator
+          # generate Docker tags based on the following events/attributes
+          tags: |
+            type=ref,event=branch
+            type=semver,pattern={{raw}}
+          labels: |
+            org.opencontainers.image.title=metallboperator
+            org.opencontainers.image.description=operator for metallb, a network load-balancer implementation for Kubernetes using standard routing protocols
+
+      - name: Build and push metallboperator
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          file: ${{matrix.image}}/Dockerfile
+          platforms: linux/amd64,linux/arm64,linux/s390x,linux/ppc64le,linux/arm/v7
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          push: true
+          build-args: |
+            GIT_BRANCH: ${{ github.ref_name }}
+            GIT_COMMIT: ${{ github.sha }}
+
+  release:
+    needs: [publish-image]
     runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/v') # we craft releases only for tags
     steps:
       - name: Checkout code
         uses: actions/checkout@v2

--- a/.github/workflows/upgrade.yml
+++ b/.github/workflows/upgrade.yml
@@ -38,7 +38,7 @@ jobs:
 
     - name: Build image
       run: |
-        docker build . -t ${built_image_prev_release}
+        IMG=${built_image_prev_release} make docker-build
     - name: Create K8s Kind Cluster
       run: |
         ./hack/kind-cluster-without-registry.sh
@@ -77,7 +77,7 @@ jobs:
     - name: Build image
       run: |
         cd ${GITHUB_WORKSPACE}/metallboperator-latest
-        docker build . -t ${built_image}
+        IMG=${built_image} make docker-build
         kind load docker-image ${built_image}
     - name: Deploy Metal LB Operator
       run: |

--- a/.github/workflows/upgrade.yml
+++ b/.github/workflows/upgrade.yml
@@ -21,7 +21,7 @@ jobs:
       built_image: "metallb-operator:ci" # Arbitrary name
     strategy:
       matrix:
-        go: [ '1.17' ]
+        go: [ '1.17' ] # this need to stay to 1.17 as long as the previous release is v0.12
     name: Go ${{ matrix.go }}
     steps:
     - name: Cancel Previous Runs

--- a/.github/workflows/upgrade.yml
+++ b/.github/workflows/upgrade.yml
@@ -24,6 +24,10 @@ jobs:
         go: [ '1.17' ]
     name: Go ${{ matrix.go }}
     steps:
+    - name: Cancel Previous Runs
+      uses: styfle/cancel-workflow-action@0.9.1
+      with:
+        access_token: ${{ github.token }}
     - name: Checkout Previous Release Metal LB Operator
       uses: actions/checkout@v2
       with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
-# Build the manager binary
-FROM golang:1.18 as builder
+# syntax=docker/dockerfile:1.2
+
+FROM --platform=$BUILDPLATFORM docker.io/golang:1.18.3 AS builder
+ARG GIT_COMMIT=dev
+ARG GIT_BRANCH=dev
 
 WORKDIR /workspace
 # Copy the Go Modules manifests
@@ -18,15 +21,43 @@ COPY bindata/deployment/ bindata/deployment/
 COPY .git/ .git/
 COPY Makefile Makefile
 
-# Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -ldflags "-X main.build=$(git rev-parse HEAD)" -o manager main.go 
+ARG TARGETARCH
+ARG TARGETOS
+ARG TARGETPLATFORM
+
+RUN case ${TARGETPLATFORM} in \
+    "linux/arm/v6") export VARIANT="6" ;; \
+    "linux/arm/v7") export VARIANT="7" ;; \
+    *) export VARIANT="" ;; \
+    esac
+
+# Cache builds directory for faster rebuild
+RUN --mount=type=cache,target=/root/.cache/go-build \
+    --mount=type=cache,target=/go/pkg \
+    CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH GOARM=$VARIANT \
+    go build -v -o /build/configmaptocrs \
+    -ldflags "-X 'main.build==${GIT_COMMIT}'" \
+    -o manager main.go
+
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
 FROM gcr.io/distroless/static:nonroot
 WORKDIR /
+
+COPY LICENSE /
 COPY --from=builder /workspace/manager .
 COPY --from=builder /workspace/bindata/deployment /bindata/deployment
+
+LABEL org.opencontainers.image.authors="metallb" \
+    org.opencontainers.image.url="https://github.com/metallb/metallb-operator" \
+    org.opencontainers.image.documentation="https://metallb.universe.tf" \
+    org.opencontainers.image.source="https://github.com/metallb/metallb-operator" \
+    org.opencontainers.image.vendor="metallb" \
+    org.opencontainers.image.licenses="Apache-2.0" \
+    org.opencontainers.image.description="Metallb Operator" \
+    org.opencontainers.image.title="metallb operator" \
+    org.opencontainers.image.base.name="gcr.io/distroless/static:nonroot"
 
 USER nonroot:nonroot
 

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,9 @@
 SHELL := /bin/bash
 
 # Current Operator version
-VERSION ?= latest
+VERSION ?= main
 CSV_VERSION = $(shell echo $(VERSION) | sed 's/v//')
-ifeq ($(VERSION), latest)
+ifeq ($(VERSION), main)
 CSV_VERSION := 0.0.0
 endif
 # Default image repo

--- a/Makefile
+++ b/Makefile
@@ -115,7 +115,7 @@ generate: controller-gen  ## Generate code
 
 # Build the docker image
 docker-build:  ## Build the docker image
-	docker build . -t ${IMG}
+	docker buildx build --load --platform linux/amd64 -t ${IMG} --build-arg GIT_COMMIT="$(shell git rev-parse HEAD)" .
 
 docker-push:  ## Push the docker image
 	docker push ${IMG}

--- a/bin/metallb-operator.yaml
+++ b/bin/metallb-operator.yaml
@@ -1536,7 +1536,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: quay.io/metallb/metallb-operator:latest
+        image: quay.io/metallb/metallb-operator:main
         name: manager
         resources:
           requests:

--- a/bundle/manifests/metallb-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/metallb-operator.clusterserviceversion.yaml
@@ -538,7 +538,7 @@ spec:
                         valueFrom:
                           fieldRef:
                             fieldPath: metadata.namespace
-                    image: quay.io/metallb/metallb-operator:latest
+                    image: quay.io/metallb/metallb-operator:main
                     name: manager
                     resources:
                       requests:

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -7,4 +7,4 @@ patchesStrategicMerge:
 images:
   - name: controller
     newName: quay.io/metallb/metallb-operator
-    newTag: latest
+    newTag: main

--- a/config/olm-install/install-resources.yaml
+++ b/config/olm-install/install-resources.yaml
@@ -10,7 +10,7 @@ metadata:
   namespace: mymetallb
 spec:
   displayName: MetalLB Operator Upstream
-  image: quay.io/metallb/metallb-operator-bundle-index:latest
+  image: quay.io/metallb/metallb-operator-bundle-index:main
   publisher: github.com/metallb/metallb-operator
   sourceType: grpc
 ---

--- a/hack/bump_versions.sh
+++ b/hack/bump_versions.sh
@@ -10,7 +10,7 @@ yq e --inplace '.spec.template.spec.containers[0].env[] |= select (.name=="CONTR
 
 operator_version=$(cat hack/operator_version.txt)
 csv_version=$(echo "$operator_version" | sed 's/v//')
-if [ $operator_version = "latest" ]; then # operator sdk doesn't like string versions, if we are on main we don't care about the version in the csv
+if [ $operator_version = "main" ]; then # operator sdk doesn't like string versions, if we are on main we don't care about the version in the csv
     csv_version="0.0.0" 
 fi
 
@@ -18,7 +18,7 @@ yq e --inplace '.spec.install.spec.deployments.[0].spec.template.spec.containers
 yq e --inplace '.spec.version |= "'$csv_version'"' bundle/manifests/metallb-operator.clusterserviceversion.yaml
 yq e --inplace '.images[] |= select (.name == "controller") |= .newTag="'$operator_version'"' config/manager/kustomization.yaml
 
-if [ "$operator_version" != "latest" ]; then
+if [ "$operator_version" != "main" ]; then
 sed -i "s/name: metallb-operator.v0.0.0/name: metallb-operator.v$operator_version/" bundle/manifests/metallb-operator.clusterserviceversion.yaml
 fi
 
@@ -28,4 +28,4 @@ sed -E -i "s/VERSION \?= .*$/VERSION \?= $operator_version/g" Makefile
 
 sed -i "s/quay.io\/metallb\/speaker:main/quay.io\/metallb\/speaker:$metallb_version/g" bin/metallb-operator.yaml
 sed -i "s/quay.io\/metallb\/controller:main/quay.io\/metallb\/controller:$metallb_version/g" bin/metallb-operator.yaml
-sed -i "s/quay.io\/metallb\/metallb-operator:latest/quay.io\/metallb\/metallb-operator:$operator_version/g" bin/metallb-operator.yaml
+sed -i "s/quay.io\/metallb\/metallb-operator:main/quay.io\/metallb\/metallb-operator:$operator_version/g" bin/metallb-operator.yaml

--- a/hack/operator_version.txt
+++ b/hack/operator_version.txt
@@ -1,1 +1,1 @@
-latest
+main


### PR DESCRIPTION
Align the metallb operator CI to the docker one.
Multi arch docker builds, cancel action, cutting the release after the images are published.

Fixes https://github.com/metallb/metallb-operator/issues/190