### PR TITLE
CI: remove the checkout path on the publish job

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -20,7 +20,6 @@ jobs:
       - name: Checkout Metal LB Operator
         uses: actions/checkout@v2
         with:
-          path: metallboperator
           fetch-depth: 0 # Fetch all history for all tags and branches
 
       - uses: actions/setup-go@v2


### PR DESCRIPTION
No need to specify a path, since we don't have the working directory
specified.
Fixing the broken publish job.