### PR TITLE
Bump versions: don't add the v in the csv name

### DIFF
--- a/hack/bump_versions.sh
+++ b/hack/bump_versions.sh
@@ -19,7 +19,7 @@ yq e --inplace '.spec.version |= "'$csv_version'"' bundle/manifests/metallb-oper
 yq e --inplace '.images[] |= select (.name == "controller") |= .newTag="'$operator_version'"' config/manager/kustomization.yaml
 
 if [ "$operator_version" != "main" ]; then
-sed -i "s/name: metallb-operator.v0.0.0/name: metallb-operator.v$operator_version/" bundle/manifests/metallb-operator.clusterserviceversion.yaml
+sed -i "s/name: metallb-operator.v0.0.0/name: metallb-operator.$operator_version/" bundle/manifests/metallb-operator.clusterserviceversion.yaml
 fi
 
 yq e --inplace '. |= select (.kind == "CatalogSource") |= .spec.image="quay.io/metallb/metallb-operator-bundle-index:'$operator_version'"' config/olm-install/install-resources.yaml


### PR DESCRIPTION
The version from the file already contains the v, no need to add it or
it will result in vv1.2.3
