### PR TITLE
Bump the metallb version

### DIFF
--- a/.github/workflows/metallb_e2e.yml
+++ b/.github/workflows/metallb_e2e.yml
@@ -49,7 +49,7 @@ jobs:
         with:
           repository: metallb/metallb
           path: metallb
-          ref: d2b2f808e36f4e15cc8f3a32bfacb1ec02fe0ef1
+          ref: 5027a1b714c0d784acc5473b2da3595fb1767432
       - name: Checkout MetalLB v0.12.1
         uses: actions/checkout@v2
         with:

--- a/bin/metallb-operator.yaml
+++ b/bin/metallb-operator.yaml
@@ -1629,7 +1629,7 @@ apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   creationTimestamp: null
-  name: validating-webhook-configuration
+  name: metallb-webhook-configuration
 webhooks:
 - admissionReviewVersions:
   - v1
@@ -1749,6 +1749,26 @@ webhooks:
     - UPDATE
     resources:
     - ipaddresspools
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: metallb-system
+      path: /validate-metallb-io-v1beta1-l2advertisement
+  failurePolicy: Fail
+  name: l2advertisementvalidationwebhook.metallb.io
+  rules:
+  - apiGroups:
+    - metallb.io
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - l2advertisements
   sideEffects: None
 ---
 apiVersion: v1

--- a/bundle/manifests/metallb-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/metallb-operator.clusterserviceversion.yaml
@@ -1010,6 +1010,26 @@ spec:
       type: ValidatingAdmissionWebhook
       webhookPath: /validate-metallb-io-v1beta1-ipaddresspool
     - admissionReviewVersions:
+        - v1
+      containerPort: 443
+      deploymentName: metallb-operator-webhook-server
+      failurePolicy: Fail
+      generateName: l2advertisementvalidationwebhook.metallb.io
+      rules:
+        - apiGroups:
+            - metallb.io
+          apiVersions:
+            - v1beta1
+          operations:
+            - CREATE
+            - UPDATE
+          resources:
+            - l2advertisements
+      sideEffects: None
+      targetPort: 9443
+      type: ValidatingAdmissionWebhook
+      webhookPath: /validate-metallb-io-v1beta1-l2advertisement
+    - admissionReviewVersions:
         - v1alpha1
         - v1beta1
       containerPort: 443

--- a/config/webhook/webhook/kustomization.yaml
+++ b/config/webhook/webhook/kustomization.yaml
@@ -5,3 +5,10 @@ resources:
 
 configurations:
 - kustomizeconfig.yaml
+
+patchesJson6902:
+- path: patches/patch_webhook_configuration.yaml
+  target:
+    version: v1
+    kind: ValidatingWebhookConfiguration
+    name: validating-webhook-configuration

--- a/config/webhook/webhook/manifests.yaml
+++ b/config/webhook/webhook/manifests.yaml
@@ -125,3 +125,23 @@ webhooks:
     resources:
     - ipaddresspools
   sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /validate-metallb-io-v1beta1-l2advertisement
+  failurePolicy: Fail
+  name: l2advertisementvalidationwebhook.metallb.io
+  rules:
+  - apiGroups:
+    - metallb.io
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - l2advertisements
+  sideEffects: None

--- a/config/webhook/webhook/patches/patch_webhook_configuration.yaml
+++ b/config/webhook/webhook/patches/patch_webhook_configuration.yaml
@@ -1,0 +1,4 @@
+- op: replace
+  path: /metadata/name
+  value: metallb-webhook-configuration
+  

--- a/hack/common.sh
+++ b/hack/common.sh
@@ -17,7 +17,7 @@ export PATH=$PATH:$GOPATH/bin
 
 mkdir -p _cache
 
-export METALLB_COMMIT_ID="d2b2f808e36f4e15cc8f3a32bfacb1ec02fe0ef1"
+export METALLB_COMMIT_ID="5027a1b714c0d784acc5473b2da3595fb1767432"
 export METALLB_PATH=_cache/metallb
 
 export METALLB_SC_FILE=$(dirname "$0")/securityContext.yaml

--- a/hack/ocp-kustomize-overlay/webhookcainjection-patch.yaml
+++ b/hack/ocp-kustomize-overlay/webhookcainjection-patch.yaml
@@ -2,6 +2,6 @@
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
-  name: validating-webhook-configuration
+  name: metallb-webhook-configuration
   annotations:
     service.beta.openshift.io/inject-cabundle: "true"


### PR DESCRIPTION
Includes the renaming of the validating webhook configuration when
deploying via manifests.
