### PR TITLE
Remove the accounts from the bundle

### DIFF
--- a/bundle/manifests/controller_v1_serviceaccount.yaml
+++ b/bundle/manifests/controller_v1_serviceaccount.yaml
@@ -1,7 +1,0 @@
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  creationTimestamp: null
-  labels:
-    app: metallb
-  name: controller

--- a/bundle/manifests/speaker_v1_serviceaccount.yaml
+++ b/bundle/manifests/speaker_v1_serviceaccount.yaml
@@ -1,7 +1,0 @@
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  creationTimestamp: null
-  labels:
-    app: metallb
-  name: speaker


### PR DESCRIPTION
Changing to match what we delivered in community operators, due the
extra consistency checks applied now. The operator sdk bundle
verification fails if the accounts are already defined in the csv.

Signed-off-by: Federico Paolinelli <fpaoline@redhat.com>