### PR TITLE
Set appropriate security context for OpenShift

### DIFF
--- a/pkg/helm/config.go
+++ b/pkg/helm/config.go
@@ -132,6 +132,8 @@ func withControllerValues(c *chartConfig, crdConfig *metallbv1beta1.MetalLB, val
 	if c.isOpenShift {
 		controllerValueMap["securityContext"] = map[string]interface{}{
 			"runAsNonRoot": true,
+			"runAsUser":    nil,
+			"fsGroup":      nil,
 		}
 		controllerValueMap["command"] = "/controller"
 	}


### PR DESCRIPTION
This would override helm's default security context values
to make it work on OpenShift deployment.

Signed-off-by: Periyasamy Palanisamy <pepalani@redhat.com>