### PR TITLE
Bump metallb: readiness probe wrapped by http

### DIFF
--- a/.github/workflows/metallb_e2e.yml
+++ b/.github/workflows/metallb_e2e.yml
@@ -49,7 +49,7 @@ jobs:
         with:
           repository: metallb/metallb
           path: metallb
-          ref: 4b236c70e03c6bc1ae7227e404f561fb159601ee
+          ref: 87842bdc6e0e42754f93ecccef2bcdac596ccd06
       - name: Checkout MetalLB v0.12.1
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/upgrade.yml
+++ b/.github/workflows/upgrade.yml
@@ -88,6 +88,13 @@ jobs:
       run: |
         cd ${GITHUB_WORKSPACE}/metallboperator-latest
         IMG=${built_image} KUSTOMIZE_DEPLOY_DIR="config/kind-ci/"  make deploy
+    - name: Ensure MetalLB operator is ready
+      run: |
+        sleep 5
+        while [ "$(kubectl get pods -n metallb-system -l control-plane='controller-manager' -o jsonpath='{.items[*].status.containerStatuses[0].ready}')" != "true" ]; do
+          sleep 5
+          echo "Waiting for operator pod to be ready."
+        done
     - name: E2E Tests
       run: |
         cd ${GITHUB_WORKSPACE}/metallboperator-latest

--- a/bindata/deployment/helm/README.md
+++ b/bindata/deployment/helm/README.md
@@ -143,6 +143,9 @@ Kubernetes: `>= 1.19.0-0`
 | speaker.serviceAccount.annotations | object | `{}` |  |
 | speaker.serviceAccount.create | bool | `true` |  |
 | speaker.serviceAccount.name | string | `""` |  |
+| speaker.startupProbe.enabled | bool | `true` |  |
+| speaker.startupProbe.failureThreshold | int | `30` |  |
+| speaker.startupProbe.periodSeconds | int | `5` |  |
 | speaker.tolerateMaster | bool | `true` |  |
 | speaker.tolerations | list | `[]` |  |
 | speaker.updateStrategy.type | string | `"RollingUpdate"` |  |

--- a/bindata/deployment/helm/templates/speaker.yaml
+++ b/bindata/deployment/helm/templates/speaker.yaml
@@ -165,8 +165,6 @@ spec:
           emptyDir: {}
         - name: metrics
           emptyDir: {}
-        - name: frr-liveness
-          emptyDir: {}
       {{- if .Values.prometheus.speakerMetricsTLSSecret }}
         - name: metrics-certs
           secret:
@@ -192,13 +190,6 @@ spec:
           volumeMounts:
             - name: reloader
               mountPath: /etc/frr_reloader
-        # Copies the liveness probe script to the shared volume between the speaker and reloader.
-        - name: cp-liveness
-          image: {{ .Values.speaker.image.repository }}:{{ .Values.speaker.image.tag | default .Chart.AppVersion }}
-          command: ["/bin/sh", "-c", "cp -f /liveness.sh /etc/frr_liveness/"]
-          volumeMounts:
-            - name: frr-liveness
-              mountPath: /etc/frr_liveness
         # Copies the metrics exporter
         - name: cp-metrics
           image: {{ .Values.speaker.image.repository }}:{{ .Values.speaker.image.tag | default .Chart.AppVersion }}
@@ -332,8 +323,6 @@ spec:
             mountPath: /var/run/frr
           - name: frr-conf
             mountPath: /etc/frr
-          - name: frr-liveness
-            mountPath: /etc/frr_liveness
         # The command is FRR's default entrypoint & waiting for the log file to appear and tailing it.
         # If the log file isn't created in 60 seconds the tail fails and the container is restarted.
         # This workaround is needed to have the frr logs as part of kubectl logs -c frr < speaker_pod_name >.
@@ -352,16 +341,22 @@ spec:
         resources:
           {{- toYaml . | nindent 12 }}
         {{- end }}
+        {{- if .Values.speaker.livenessProbe.enabled }}
         livenessProbe:
-          exec:
-            command: ["/etc/frr_liveness/liveness.sh"]
-          periodSeconds: 5
-          failureThreshold: 3
+          httpGet:
+            path: /livez
+            port: {{ .Values.speaker.frr.metricsPort }}
+          periodSeconds: {{ .Values.speaker.livenessProbe.periodSeconds }}
+          failureThreshold: {{ .Values.speaker.livenessProbe.failureThreshold }}
+        {{- end }}
+        {{- if .Values.speaker.startupProbe.enabled }}
         startupProbe:
-          exec:
-            command: ["/etc/frr_liveness/liveness.sh"]
-          failureThreshold: 30
-          periodSeconds: 5
+          httpGet:
+            path: /livez
+            port: {{ .Values.speaker.frr.metricsPort }}
+          failureThreshold: {{ .Values.speaker.startupProbe.failureThreshold }}
+          periodSeconds: {{ .Values.speaker.startupProbe.periodSeconds }}
+        {{- end }}
       - name: reloader
         image: {{ .Values.speaker.frr.image.repository }}:{{ .Values.speaker.frr.image.tag | default .Chart.AppVersion }}
         {{- if .Values.speaker.frr.image.pullPolicy }}

--- a/bindata/deployment/helm/values.yaml
+++ b/bindata/deployment/helm/values.yaml
@@ -307,6 +307,10 @@ speaker:
     periodSeconds: 10
     successThreshold: 1
     timeoutSeconds: 1
+  startupProbe:
+    enabled: true
+    failureThreshold: 30
+    periodSeconds: 5
   # frr contains configuration specific to the MetalLB FRR container,
   # for speaker running alongside FRR.
   frr:

--- a/hack/common.sh
+++ b/hack/common.sh
@@ -17,7 +17,7 @@ export PATH=$PATH:$GOPATH/bin
 
 mkdir -p _cache
 
-export METALLB_COMMIT_ID="4b236c70e03c6bc1ae7227e404f561fb159601ee"
+export METALLB_COMMIT_ID="87842bdc6e0e42754f93ecccef2bcdac596ccd06"
 export METALLB_PATH=_cache/metallb
 
 export METALLB_SC_FILE=$(dirname "$0")/securityContext.yaml

--- a/pkg/helm/testdata/ocp-metrics-speaker.golden
+++ b/pkg/helm/testdata/ocp-metrics-speaker.golden
@@ -163,13 +163,12 @@
                         ],
                         "image": "frrouting/frr:v7.5.1",
                         "livenessProbe": {
-                            "exec": {
-                                "command": [
-                                    "/etc/frr_liveness/liveness.sh"
-                                ]
-                            },
                             "failureThreshold": 3,
-                            "periodSeconds": 5
+                            "httpGet": {
+                                "path": "/livez",
+                                "port": 7473
+                            },
+                            "periodSeconds": 10
                         },
                         "name": "frr",
                         "securityContext": {
@@ -183,12 +182,11 @@
                             }
                         },
                         "startupProbe": {
-                            "exec": {
-                                "command": [
-                                    "/etc/frr_liveness/liveness.sh"
-                                ]
-                            },
                             "failureThreshold": 30,
+                            "httpGet": {
+                                "path": "/livez",
+                                "port": 7473
+                            },
                             "periodSeconds": 5
                         },
                         "volumeMounts": [
@@ -199,10 +197,6 @@
                             {
                                 "mountPath": "/etc/frr",
                                 "name": "frr-conf"
-                            },
-                            {
-                                "mountPath": "/etc/frr_liveness",
-                                "name": "frr-liveness"
                             }
                         ]
                     },
@@ -388,21 +382,6 @@
                         "command": [
                             "/bin/sh",
                             "-c",
-                            "cp -f /liveness.sh /etc/frr_liveness/"
-                        ],
-                        "image": "quay.io/metallb/speaker:v0.0.0",
-                        "name": "cp-liveness",
-                        "volumeMounts": [
-                            {
-                                "mountPath": "/etc/frr_liveness",
-                                "name": "frr-liveness"
-                            }
-                        ]
-                    },
-                    {
-                        "command": [
-                            "/bin/sh",
-                            "-c",
                             "cp -f /frr-metrics /etc/frr_metrics/"
                         ],
                         "image": "quay.io/metallb/speaker:v0.0.0",
@@ -462,10 +441,6 @@
                     {
                         "emptyDir": {},
                         "name": "metrics"
-                    },
-                    {
-                        "emptyDir": {},
-                        "name": "frr-liveness"
                     },
                     {
                         "name": "metrics-certs",

--- a/pkg/helm/testdata/vanilla-metrics-speaker.golden
+++ b/pkg/helm/testdata/vanilla-metrics-speaker.golden
@@ -163,13 +163,12 @@
                         ],
                         "image": "frrouting/frr:v7.5.1",
                         "livenessProbe": {
-                            "exec": {
-                                "command": [
-                                    "/etc/frr_liveness/liveness.sh"
-                                ]
-                            },
                             "failureThreshold": 3,
-                            "periodSeconds": 5
+                            "httpGet": {
+                                "path": "/livez",
+                                "port": 7473
+                            },
+                            "periodSeconds": 10
                         },
                         "name": "frr",
                         "securityContext": {
@@ -183,12 +182,11 @@
                             }
                         },
                         "startupProbe": {
-                            "exec": {
-                                "command": [
-                                    "/etc/frr_liveness/liveness.sh"
-                                ]
-                            },
                             "failureThreshold": 30,
+                            "httpGet": {
+                                "path": "/livez",
+                                "port": 7473
+                            },
                             "periodSeconds": 5
                         },
                         "volumeMounts": [
@@ -199,10 +197,6 @@
                             {
                                 "mountPath": "/etc/frr",
                                 "name": "frr-conf"
-                            },
-                            {
-                                "mountPath": "/etc/frr_liveness",
-                                "name": "frr-liveness"
                             }
                         ]
                     },
@@ -370,21 +364,6 @@
                         "command": [
                             "/bin/sh",
                             "-c",
-                            "cp -f /liveness.sh /etc/frr_liveness/"
-                        ],
-                        "image": "quay.io/metallb/speaker:v0.0.0",
-                        "name": "cp-liveness",
-                        "volumeMounts": [
-                            {
-                                "mountPath": "/etc/frr_liveness",
-                                "name": "frr-liveness"
-                            }
-                        ]
-                    },
-                    {
-                        "command": [
-                            "/bin/sh",
-                            "-c",
                             "cp -f /frr-metrics /etc/frr_metrics/"
                         ],
                         "image": "quay.io/metallb/speaker:v0.0.0",
@@ -444,10 +423,6 @@
                     {
                         "emptyDir": {},
                         "name": "metrics"
-                    },
-                    {
-                        "emptyDir": {},
-                        "name": "frr-liveness"
                     }
                 ]
             }


### PR DESCRIPTION
Bumping metallb again, consuming the version where we wrap the liveness probe execution behind http.