### PR TITLE
Fix invalid verification error when using aggregationLengthV6 only

### DIFF
--- a/api/v1beta1/addresspool_webhook.go
+++ b/api/v1beta1/addresspool_webhook.go
@@ -241,8 +241,10 @@ func validateAggregationLength(aggregationLength int32, isV6 bool, poolAddresses
 		if len(cidrs) == 0 {
 			continue
 		}
-
-		if isV6 && cidrs[0].IP.To4() != nil {
+		// skip aggregation length validation against configured CIDR if
+		// the configuration has aggregationLengthV6 and CIDR is an IPv4 address
+		// or the configuration has aggregationLength and CIDR is an IPv6 address.
+		if isV6 && cidrs[0].IP.To4() != nil || !isV6 && cidrs[0].IP.To4() == nil {
 			continue
 		}
 


### PR DESCRIPTION
Verification webhook incorrectly fails when BGP Adv. has only aggregationLengthV6 configured with IPv6 address pools only, because aggregationLength has default of 32 adv.AggregationLength will always be != nil even with ipv6 only config.

Signed-off-by: msherif1234 <mmahmoud@redhat.com>