### PR TITLE
Use ginkgo/v2 CLI --junit-report flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,15 +57,15 @@ test: generate fmt vet manifests ## Run unit and integration tests
 
 all: manager ## Default make target if no options specified
 
-test-validation: generate fmt vet manifests  ## Run validation tests
+test-validation: generate fmt vet manifests ginkgo  ## Run validation tests
 	rm -rf ${VALIDATION_TESTS_REPORTS_PATH}
 	mkdir -p ${VALIDATION_TESTS_REPORTS_PATH}
-	USE_LOCAL_RESOURCES=true go test --tags=validationtests -v ./test/e2e/validation -ginkgo.v -junit $(VALIDATION_TESTS_REPORTS_PATH) -report $(VALIDATION_TESTS_REPORTS_PATH)
+	USE_LOCAL_RESOURCES=true $(GINKGO) --output-dir=$(VALIDATION_TESTS_REPORTS_PATH) --junit-report=validation_junit.xml --tags=validationtests -v ./test/e2e/validation -ginkgo.v -- -report $(VALIDATION_TESTS_REPORTS_PATH)
 
-test-functional: generate fmt vet manifests  ## Run e2e tests
+test-functional: generate fmt vet manifests ginkgo  ## Run e2e tests
 	rm -rf ${TESTS_REPORTS_PATH}
 	mkdir -p ${TESTS_REPORTS_PATH}
-	USE_LOCAL_RESOURCES=true go test --tags=e2etests -v ./test/e2e/functional -ginkgo.v -junit $(TESTS_REPORTS_PATH) -report $(TESTS_REPORTS_PATH)
+	USE_LOCAL_RESOURCES=true $(GINKGO) --output-dir=$(TESTS_REPORTS_PATH) --junit-report=e2e_junit.xml --tags=e2etests -v ./test/e2e/functional -ginkgo.v -- -report $(TESTS_REPORTS_PATH)
 
 test-e2e: generate fmt vet manifests test-validation test-functional  ## Run e2e tests
 
@@ -174,6 +174,14 @@ ifeq (, $(shell which kustomize))
 KUSTOMIZE=$(GOBIN)/kustomize
 else
 KUSTOMIZE=$(shell which kustomize)
+endif
+
+ginkgo:
+ifeq (, $(shell which ginkgo))
+	go install github.com/onsi/ginkgo/v2/ginkgo@v2.6.0
+GINKGO=$(GOBIN)/ginkgo
+else
+GINKGO=$(shell which ginkgo)
 endif
 
 # Get the current operator-sdk binary. If there isn't any, we'll use the

--- a/test/e2e/functional/e2e_test.go
+++ b/test/e2e/functional/e2e_test.go
@@ -6,7 +6,6 @@ package functional
 import (
 	"flag"
 	"os"
-	"path"
 	"testing"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -21,7 +20,6 @@ import (
 
 var OperatorNameSpace = consts.DefaultOperatorNameSpace
 
-var junitPath *string
 var reportPath *string
 var r *kniK8sReporter.KubernetesReporter
 
@@ -30,26 +28,18 @@ func init() {
 		OperatorNameSpace = ns
 	}
 
-	junitPath = flag.String("junit", "", "the path for the junit format report")
 	reportPath = flag.String("report", "", "the path of the report file containing details for failed tests")
 }
 
 func TestE2E(t *testing.T) {
 	RegisterFailHandler(Fail)
 
-	_, reporterConfig := GinkgoConfiguration()
-
-	if *junitPath != "" {
-		junitFile := path.Join(*junitPath, "e2e_junit.xml")
-		reporterConfig.JUnitReport = junitFile
-	}
-
 	if *reportPath != "" {
 		kubeconfig := os.Getenv("KUBECONFIG")
 		r = k8sreporter.New(kubeconfig, *reportPath, OperatorNameSpace)
 	}
 
-	RunSpecs(t, "Metallb Operator E2E Suite", reporterConfig)
+	RunSpecs(t, "Metallb Operator E2E Suite")
 }
 
 var _ = ReportAfterEach(func(specReport types.SpecReport) {
@@ -58,6 +48,6 @@ var _ = ReportAfterEach(func(specReport types.SpecReport) {
 	}
 
 	if *reportPath != "" {
-		k8sreporter.DumpInfo(r, specReport.FullText())
+		k8sreporter.DumpInfo(r, specReport.LeafNodeText)
 	}
 })

--- a/test/e2e/k8sreporter/reporter.go
+++ b/test/e2e/k8sreporter/reporter.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/onsi/ginkgo/v2"
 	"github.com/openshift-kni/k8sreporter"
 	metallbv1beta1 "go.universe.tf/metallb/api/v1beta1"
 	metallbv1beta2 "go.universe.tf/metallb/api/v1beta2"
@@ -62,6 +61,6 @@ func New(kubeconfig, path, namespace string) *k8sreporter.KubernetesReporter {
 }
 
 func DumpInfo(reporter *k8sreporter.KubernetesReporter, testName string) {
-	testNameNoSpaces := strings.Replace(ginkgo.CurrentGinkgoTestDescription().TestText, " ", "-", -1)
+	testNameNoSpaces := strings.Replace(testName, " ", "-", -1)
 	reporter.Dump(10*time.Minute, testNameNoSpaces)
 }

--- a/test/e2e/validation/validation_test.go
+++ b/test/e2e/validation/validation_test.go
@@ -6,7 +6,6 @@ package validation
 import (
 	"flag"
 	"os"
-	"path"
 	"testing"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -21,7 +20,6 @@ import (
 
 var OperatorNameSpace = consts.DefaultOperatorNameSpace
 
-var junitPath *string
 var reportPath *string
 var r *kniK8sReporter.KubernetesReporter
 
@@ -30,26 +28,18 @@ func init() {
 		OperatorNameSpace = ns
 	}
 
-	junitPath = flag.String("junit", "", "the path for the junit format report")
 	reportPath = flag.String("report", "", "the path of the report file containing details for failed tests")
 }
 
 func TestValidation(t *testing.T) {
 	RegisterFailHandler(Fail)
 
-	_, reporterConfig := GinkgoConfiguration()
-
-	if *junitPath != "" {
-		junitFile := path.Join(*junitPath, "validation_junit.xml")
-		reporterConfig.JUnitReport = junitFile
-	}
-
 	if *reportPath != "" {
 		kubeconfig := os.Getenv("KUBECONFIG")
 		r = k8sreporter.New(kubeconfig, *reportPath, OperatorNameSpace)
 	}
 
-	RunSpecs(t, "Metallb Operator Validation Suite", reporterConfig)
+	RunSpecs(t, "Metallb Operator Validation Suite")
 }
 
 var _ = ReportAfterEach(func(specReport types.SpecReport) {
@@ -58,6 +48,6 @@ var _ = ReportAfterEach(func(specReport types.SpecReport) {
 	}
 
 	if *reportPath != "" {
-		k8sreporter.DumpInfo(r, specReport.FullText())
+		k8sreporter.DumpInfo(r, specReport.LeafNodeText)
 	}
 })


### PR DESCRIPTION
This PR puts the ginkgo/v2 `--junit-report` CLI flag to use, which is recommended by the official [docs](https://onsi.github.io/ginkgo/MIGRATING_TO_V2#migration-strategy-5).
And it's clear to see how cleaner the test suites are without handling the junit report programmatically.

- Switches `go test` to `ginkgo` in the Makefile.
- Removes the junit code from the test suites.
- Fix the `DumpInfo` method on the reporter.go file, removing the deprecated method `CurrentGinkgoTestDescription`.