### PR TITLE
Fix the FRR image on the v0.12 branch

### DIFF
--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -22,11 +22,18 @@ jobs:
     - name: Check out code
       uses: actions/checkout@v2
 
+    - name: Set up Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: '1.16'
+      id: go
+
     - name: Verify
       uses: golangci/golangci-lint-action@v2
       with:
         version: v1.41.1
         args: --timeout=15m0s --verbose
+        skip-go-installation: true
 
   unit:
     runs-on: ubuntu-20.04

--- a/.github/workflows/metallb_e2e.yml
+++ b/.github/workflows/metallb_e2e.yml
@@ -45,7 +45,7 @@ jobs:
         with:
           repository: metallb/metallb
           path: metallb
-          ref: 46675f03d788549897ff59c6b3b268c162a394d0
+          ref: 6c7fd6186b968a84276d318b1cb4e2bbd2641ec0
       - name: Install Dependencies
         run: |
           sudo apt-get update

--- a/bin/metallb-operator-with-webhooks.yaml
+++ b/bin/metallb-operator-with-webhooks.yaml
@@ -851,7 +851,7 @@ spec:
         - name: METALLB_BGP_TYPE
           value: native
         - name: FRR_IMAGE
-          value: quay.io/frrouting/frr:stable_7.5
+          value: quay.io/frrouting/frr:7.5.1
         - name: KUBE_RBAC_PROXY_IMAGE
           value: quay.io/brancz/kube-rbac-proxy:v0.11.0
         - name: DEPLOY_KUBE_RBAC_PROXIES

--- a/bin/metallb-operator-with-webhooks.yaml
+++ b/bin/metallb-operator-with-webhooks.yaml
@@ -862,7 +862,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: quay.io/metallb/metallb-operator:v0.12.0
+        image: quay.io/metallb/metallb-operator:v0.12.1
         name: manager
         ports:
         - containerPort: 9443
@@ -910,6 +910,7 @@ kind: ValidatingWebhookConfiguration
 metadata:
   annotations:
     cert-manager.io/inject-ca-from: metallb-system/serving-cert
+  creationTimestamp: null
   name: validating-webhook-configuration
 webhooks:
 - admissionReviewVersions:

--- a/bin/metallb-operator.yaml
+++ b/bin/metallb-operator.yaml
@@ -839,7 +839,7 @@ spec:
         - name: METALLB_BGP_TYPE
           value: native
         - name: FRR_IMAGE
-          value: quay.io/frrouting/frr:stable_7.5
+          value: quay.io/frrouting/frr:7.5.1
         - name: KUBE_RBAC_PROXY_IMAGE
           value: quay.io/brancz/kube-rbac-proxy:v0.11.0
         - name: DEPLOY_KUBE_RBAC_PROXIES

--- a/bundle/manifests/metallb-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/metallb-operator.clusterserviceversion.yaml
@@ -423,7 +423,7 @@ spec:
                       - name: METALLB_BGP_TYPE
                         value: native
                       - name: FRR_IMAGE
-                        value: quay.io/frrouting/frr:stable_7.5
+                        value: quay.io/frrouting/frr:7.5.1
                       - name: KUBE_RBAC_PROXY_IMAGE
                         value: quay.io/brancz/kube-rbac-proxy:v0.11.0
                       - name: DEPLOY_KUBE_RBAC_PROXIES

--- a/config/manager/env.yaml
+++ b/config/manager/env.yaml
@@ -18,7 +18,7 @@ spec:
             - name: METALLB_BGP_TYPE
               value: "native"
             - name: FRR_IMAGE
-              value: "quay.io/frrouting/frr:stable_7.5"
+              value: "quay.io/frrouting/frr:7.5.1"
             - name: KUBE_RBAC_PROXY_IMAGE
               value: "quay.io/brancz/kube-rbac-proxy:v0.11.0"
             - name: DEPLOY_KUBE_RBAC_PROXIES

--- a/hack/generate-metallb-manifests.sh
+++ b/hack/generate-metallb-manifests.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 . $(dirname "$0")/common.sh
 
-METALLB_COMMIT_ID="46675f03d788549897ff59c6b3b268c162a394d0"
+METALLB_COMMIT_ID="6c7fd6186b968a84276d318b1cb4e2bbd2641ec0"
 METALLB_SC_FILE=$(dirname "$0")/securityContext.yaml
 
 NATIVE_MANIFESTS_FILE="metallb.yaml"


### PR DESCRIPTION
Note: this PR is changing the v0.12. not the main branch.
Replace the quay.io FRR image from stable_7.5, which is now deleted, to 7.5.1.

Signed-off-by: liornoy <lnoy@redhat.com>