### PR TITLE
Fix the quay FRR image

### DIFF
--- a/bin/metallb-operator-with-webhooks.yaml
+++ b/bin/metallb-operator-with-webhooks.yaml
@@ -851,7 +851,7 @@ spec:
         - name: METALLB_BGP_TYPE
           value: native
         - name: FRR_IMAGE
-          value: quay.io/frrouting/frr:stable_7.5
+          value: quay.io/frrouting/frr:7.5.1
         - name: KUBE_RBAC_PROXY_IMAGE
           value: quay.io/brancz/kube-rbac-proxy:v0.11.0
         - name: DEPLOY_KUBE_RBAC_PROXIES

--- a/bin/metallb-operator.yaml
+++ b/bin/metallb-operator.yaml
@@ -839,7 +839,7 @@ spec:
         - name: METALLB_BGP_TYPE
           value: native
         - name: FRR_IMAGE
-          value: quay.io/frrouting/frr:stable_7.5
+          value: quay.io/frrouting/frr:7.5.1
         - name: KUBE_RBAC_PROXY_IMAGE
           value: quay.io/brancz/kube-rbac-proxy:v0.11.0
         - name: DEPLOY_KUBE_RBAC_PROXIES

--- a/bundle/manifests/metallb-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/metallb-operator.clusterserviceversion.yaml
@@ -423,7 +423,7 @@ spec:
                       - name: METALLB_BGP_TYPE
                         value: native
                       - name: FRR_IMAGE
-                        value: quay.io/frrouting/frr:stable_7.5
+                        value: quay.io/frrouting/frr:7.5.1
                       - name: KUBE_RBAC_PROXY_IMAGE
                         value: quay.io/brancz/kube-rbac-proxy:v0.11.0
                       - name: DEPLOY_KUBE_RBAC_PROXIES

--- a/config/manager/env.yaml
+++ b/config/manager/env.yaml
@@ -18,7 +18,7 @@ spec:
             - name: METALLB_BGP_TYPE
               value: "native"
             - name: FRR_IMAGE
-              value: "quay.io/frrouting/frr:stable_7.5"
+              value: "quay.io/frrouting/frr:7.5.1"
             - name: KUBE_RBAC_PROXY_IMAGE
               value: "quay.io/brancz/kube-rbac-proxy:v0.11.0"
             - name: DEPLOY_KUBE_RBAC_PROXIES


### PR DESCRIPTION
This commit changes the FRR image from the deprecated "stable_7.5" to 7.5.1.