### PR TITLE
Bump up the used operator-sdk version

### DIFF
--- a/.github/workflows/olm.yml
+++ b/.github/workflows/olm.yml
@@ -48,7 +48,7 @@ jobs:
     - name: Verify release bundle manifests
       run: |
         make bundle-release
-        git diff --exit-code
+        git diff --exit-code --quiet -I'^    createdAt: ' bundle 
 
     - name: Create and set up K8s Kind Cluster
       run: |

--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -6,7 +6,7 @@ LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
 LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
 LABEL operators.operatorframework.io.bundle.package.v1=metallb-operator
 LABEL operators.operatorframework.io.bundle.channels.v1=alpha
-LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.8.0+git
+LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.26.1
 LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
 LABEL operators.operatorframework.io.metrics.project_layout=go.kubebuilder.io/v2
 

--- a/bundle/manifests/controller_v1_serviceaccount.yaml
+++ b/bundle/manifests/controller_v1_serviceaccount.yaml
@@ -1,7 +1,0 @@
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  creationTimestamp: null
-  labels:
-    app: metallb
-  name: controller

--- a/bundle/manifests/manager-account_v1_serviceaccount.yaml
+++ b/bundle/manifests/manager-account_v1_serviceaccount.yaml
@@ -1,5 +1,0 @@
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  creationTimestamp: null
-  name: manager-account

--- a/bundle/manifests/metallb-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/metallb-operator.clusterserviceversion.yaml
@@ -273,9 +273,9 @@ metadata:
     categories: Networking
     certified: "false"
     containerImage: quay.io/metallb/metallb-operator
-    createdAt: "2021-06-28 00:00:00"
+    createdAt: "2023-03-07T21:15:23Z"
     description: An operator for deploying MetalLB on a kubernetes cluster.
-    operators.operatorframework.io/builder: operator-sdk-v1.8.0+git
+    operators.operatorframework.io/builder: operator-sdk-v1.26.1
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v2
     repository: https://github.com/metallb/metallb-operator
     support: Community
@@ -572,7 +572,9 @@ spec:
                 - use
           serviceAccountName: speaker
       deployments:
-        - name: metallb-operator-controller-manager
+        - label:
+            control-plane: controller-manager
+          name: metallb-operator-controller-manager
           spec:
             replicas: 1
             selector:
@@ -637,7 +639,10 @@ spec:
                     secret:
                       defaultMode: 420
                       secretName: metallb-operator-webhook-server-cert
-        - name: metallb-operator-webhook-server
+        - label:
+            app: metallb
+            component: webhook-server
+          name: metallb-operator-webhook-server
           spec:
             revisionHistoryLimit: 3
             selector:
@@ -961,46 +966,6 @@ spec:
     - admissionReviewVersions:
         - v1
       containerPort: 443
-      deploymentName: metallb-operator-controller-manager
-      failurePolicy: Fail
-      generateName: metallbvalidationwebhook.metallb.io
-      rules:
-        - apiGroups:
-            - metallb.io
-          apiVersions:
-            - v1beta1
-          operations:
-            - CREATE
-            - UPDATE
-          resources:
-            - metallbs
-      sideEffects: None
-      targetPort: 9443
-      type: ValidatingAdmissionWebhook
-      webhookPath: /validate-metallb-io-v1beta1-metallb
-    - admissionReviewVersions:
-        - v1
-      containerPort: 443
-      deploymentName: metallb-operator-webhook-server
-      failurePolicy: Fail
-      generateName: bgppeersvalidationwebhook.metallb.io
-      rules:
-        - apiGroups:
-            - metallb.io
-          apiVersions:
-            - v1beta2
-          operations:
-            - CREATE
-            - UPDATE
-          resources:
-            - bgppeers
-      sideEffects: None
-      targetPort: 9443
-      type: ValidatingAdmissionWebhook
-      webhookPath: /validate-metallb-io-v1beta2-bgppeer
-    - admissionReviewVersions:
-        - v1
-      containerPort: 443
       deploymentName: metallb-operator-webhook-server
       failurePolicy: Fail
       generateName: addresspoolvalidationwebhook.metallb.io
@@ -1063,6 +1028,39 @@ spec:
       containerPort: 443
       deploymentName: metallb-operator-webhook-server
       failurePolicy: Fail
+      generateName: bgppeersvalidationwebhook.metallb.io
+      rules:
+        - apiGroups:
+            - metallb.io
+          apiVersions:
+            - v1beta2
+          operations:
+            - CREATE
+            - UPDATE
+          resources:
+            - bgppeers
+      sideEffects: None
+      targetPort: 9443
+      type: ValidatingAdmissionWebhook
+      webhookPath: /validate-metallb-io-v1beta2-bgppeer
+    - admissionReviewVersions:
+        - v1alpha1
+        - v1beta1
+      containerPort: 443
+      conversionCRDs:
+        - addresspools.metallb.io
+        - bgppeers.metallb.io
+      deploymentName: metallb-operator-webhook-server
+      generateName: caddresspoolsbgppeers.kb.io
+      sideEffects: None
+      targetPort: 9443
+      type: ConversionWebhook
+      webhookPath: /convert
+    - admissionReviewVersions:
+        - v1
+      containerPort: 443
+      deploymentName: metallb-operator-webhook-server
+      failurePolicy: Fail
       generateName: communityvalidationwebhook.metallb.io
       rules:
         - apiGroups:
@@ -1119,15 +1117,22 @@ spec:
       type: ValidatingAdmissionWebhook
       webhookPath: /validate-metallb-io-v1beta1-l2advertisement
     - admissionReviewVersions:
-        - v1alpha1
-        - v1beta1
+        - v1
       containerPort: 443
-      conversionCRDs:
-        - addresspools.metallb.io
-        - bgppeers.metallb.io
-      deploymentName: metallb-operator-webhook-server
-      generateName: caddresspoolsbgppeers.kb.io
+      deploymentName: metallb-operator-controller-manager
+      failurePolicy: Fail
+      generateName: metallbvalidationwebhook.metallb.io
+      rules:
+        - apiGroups:
+            - metallb.io
+          apiVersions:
+            - v1beta1
+          operations:
+            - CREATE
+            - UPDATE
+          resources:
+            - metallbs
       sideEffects: None
       targetPort: 9443
-      type: ConversionWebhook
-      webhookPath: /convert
+      type: ValidatingAdmissionWebhook
+      webhookPath: /validate-metallb-io-v1beta1-metallb

--- a/bundle/metadata/annotations.yaml
+++ b/bundle/metadata/annotations.yaml
@@ -5,7 +5,7 @@ annotations:
   operators.operatorframework.io.bundle.metadata.v1: metadata/
   operators.operatorframework.io.bundle.package.v1: metallb-operator
   operators.operatorframework.io.bundle.channels.v1: alpha
-  operators.operatorframework.io.metrics.builder: operator-sdk-v1.8.0+git
+  operators.operatorframework.io.metrics.builder: operator-sdk-v1.26.1
   operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
   operators.operatorframework.io.metrics.project_layout: go.kubebuilder.io/v2
 

--- a/bundle/tests/scorecard/config.yaml
+++ b/bundle/tests/scorecard/config.yaml
@@ -12,6 +12,9 @@ stages:
     labels:
       suite: basic
       test: basic-check-spec-test
+    storage:
+      spec:
+        mountPath: {}
   - entrypoint:
     - scorecard-test
     - olm-bundle-validation
@@ -19,6 +22,9 @@ stages:
     labels:
       suite: olm
       test: olm-bundle-validation-test
+    storage:
+      spec:
+        mountPath: {}
   - entrypoint:
     - scorecard-test
     - olm-crds-have-validation
@@ -26,6 +32,9 @@ stages:
     labels:
       suite: olm
       test: olm-crds-have-validation-test
+    storage:
+      spec:
+        mountPath: {}
   - entrypoint:
     - scorecard-test
     - olm-crds-have-resources
@@ -33,6 +42,9 @@ stages:
     labels:
       suite: olm
       test: olm-crds-have-resources-test
+    storage:
+      spec:
+        mountPath: {}
   - entrypoint:
     - scorecard-test
     - olm-spec-descriptors
@@ -40,6 +52,9 @@ stages:
     labels:
       suite: olm
       test: olm-spec-descriptors-test
+    storage:
+      spec:
+        mountPath: {}
   - entrypoint:
     - scorecard-test
     - olm-status-descriptors
@@ -47,3 +62,9 @@ stages:
     labels:
       suite: olm
       test: olm-status-descriptors-test
+    storage:
+      spec:
+        mountPath: {}
+storage:
+  spec:
+    mountPath: {}


### PR DESCRIPTION
This PR bumps the operator-sdk to the latest version
and make the Makefile script download the binary to _cache and use that.

fixes #282 