### PR TITLE
Bump the metallb version

### DIFF
--- a/.github/workflows/metallb_e2e.yml
+++ b/.github/workflows/metallb_e2e.yml
@@ -49,7 +49,7 @@ jobs:
         with:
           repository: metallb/metallb
           path: metallb
-          ref: 790e6e98187e523edf715d4b0a60e38baca712fd
+          ref: 7b6d91db081433e9121d68b6e88e316394dcbc4c
       - name: Checkout MetalLB v0.12
         uses: actions/checkout@v2
         with:

--- a/bin/metallb-operator.yaml
+++ b/bin/metallb-operator.yaml
@@ -4016,6 +4016,14 @@ rules:
   - list
   - watch
 - apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - metallb.io
   resources:
   - addresspools
@@ -4124,6 +4132,12 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - list
 - apiGroups:
   - ""
   resources:

--- a/bindata/deployment/helm/README.md
+++ b/bindata/deployment/helm/README.md
@@ -27,6 +27,7 @@ Kubernetes: `>= 1.19.0-0`
 | controller.image.pullPolicy | string | `nil` |  |
 | controller.image.repository | string | `"quay.io/metallb/controller"` |  |
 | controller.image.tag | string | `nil` |  |
+| controller.labels | object | `{}` |  |
 | controller.livenessProbe.enabled | bool | `true` |  |
 | controller.livenessProbe.failureThreshold | int | `3` |  |
 | controller.livenessProbe.initialDelaySeconds | int | `10` |  |
@@ -109,6 +110,7 @@ Kubernetes: `>= 1.19.0-0`
 | rbac.create | bool | `true` |  |
 | speaker.affinity | object | `{}` |  |
 | speaker.enabled | bool | `true` |  |
+| speaker.excludeInterfaces.enabled | bool | `true` |  |
 | speaker.frr.enabled | bool | `false` |  |
 | speaker.frr.image.pullPolicy | string | `nil` |  |
 | speaker.frr.image.repository | string | `"quay.io/frrouting/frr"` |  |
@@ -119,6 +121,7 @@ Kubernetes: `>= 1.19.0-0`
 | speaker.image.pullPolicy | string | `nil` |  |
 | speaker.image.repository | string | `"quay.io/metallb/speaker"` |  |
 | speaker.image.tag | string | `nil` |  |
+| speaker.labels | object | `{}` |  |
 | speaker.livenessProbe.enabled | bool | `true` |  |
 | speaker.livenessProbe.failureThreshold | int | `3` |  |
 | speaker.livenessProbe.initialDelaySeconds | int | `10` |  |

--- a/bindata/deployment/helm/templates/controller.yaml
+++ b/bindata/deployment/helm/templates/controller.yaml
@@ -6,6 +6,9 @@ metadata:
   labels:
     {{- include "metallb.labels" . | nindent 4 }}
     component: controller
+    {{- range $key, $value := .Values.controller.labels }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
 spec:
   {{- if .Values.controller.strategy }}
   strategy: {{- toYaml .Values.controller.strategy | nindent 4 }}
@@ -29,6 +32,9 @@ spec:
       labels:
         {{- include "metallb.selectorLabels" . | nindent 8 }}
         component: controller
+        {{- range $key, $value := .Values.controller.labels }}
+        {{ $key }}: {{ $value | quote }}
+        {{- end }}
     spec:
       {{- with .Values.controller.runtimeClassName }}
       runtimeClassName: {{ . | quote }}

--- a/bindata/deployment/helm/templates/exclude-l2-config.yaml
+++ b/bindata/deployment/helm/templates/exclude-l2-config.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.speaker.excludeInterfaces.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: metallb-excludel2
+data:
+  excludel2.yaml: |
+    announcedInterfacesToExclude:
+    - docker.*
+    - cbr.*
+    - dummy.*
+    - virbr.*
+    - lxcbr.*
+    - veth.*
+    - lo
+    - ^cali.*
+    - ^tunl.*
+    - flannel.*
+    - kube-ipvs.*
+    - cni.*
+    - ^nodelocaldns.*
+{{- end }}

--- a/bindata/deployment/helm/templates/servicemonitor.yaml
+++ b/bindata/deployment/helm/templates/servicemonitor.yaml
@@ -58,14 +58,6 @@ spec:
   selector:
     matchLabels:
       name: speaker-monitor-service
-{{- if .Values.prometheus.serviceMonitor.metricRelabelings }}
-  metricRelabelings:
-{{- toYaml .Values.prometheus.serviceMonitor.metricRelabelings | nindent 4 }}
-{{- end }}
-{{- if .Values.prometheus.serviceMonitor.relabelings }}
-  relabelings:
-{{- toYaml .Values.prometheus.serviceMonitor.relabelings | nindent 4 }}
-{{- end }}      
 ---
 apiVersion: v1
 kind: Service
@@ -112,6 +104,14 @@ metadata:
 spec:
   endpoints:
     - port: {{ template "metrics.exposedportname" . }}
+      {{- if .Values.prometheus.serviceMonitor.metricRelabelings }}
+      metricRelabelings:
+      {{- toYaml .Values.prometheus.serviceMonitor.metricRelabelings | nindent 8 }}
+      {{- end -}}
+      {{- if .Values.prometheus.serviceMonitor.relabelings }}
+      relabelings:
+      {{- toYaml .Values.prometheus.serviceMonitor.relabelings | nindent 8 }}
+      {{- end }}
       {{- if .Values.prometheus.serviceMonitor.interval }}
       interval: {{ .Values.prometheus.serviceMonitor.interval }}
       {{- end }}
@@ -131,14 +131,6 @@ spec:
   selector:
     matchLabels:
       name: controller-monitor-service
-{{- if .Values.prometheus.serviceMonitor.metricRelabelings }}
-  metricRelabelings:
-{{- toYaml .Values.prometheus.serviceMonitor.metricRelabelings | nindent 4 }}
-{{- end }}
-{{- if .Values.prometheus.serviceMonitor.relabelings }}
-  relabelings:
-{{- toYaml .Values.prometheus.serviceMonitor.relabelings | nindent 4 }}
-{{- end }}      
 ---
 apiVersion: v1
 kind: Service

--- a/bindata/deployment/helm/templates/speaker.yaml
+++ b/bindata/deployment/helm/templates/speaker.yaml
@@ -110,6 +110,9 @@ metadata:
   labels:
     {{- include "metallb.labels" . | nindent 4 }}
     component: speaker
+    {{- range $key, $value := .Values.speaker.labels }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
 spec:
   {{- if .Values.speaker.updateStrategy }}
   updateStrategy: {{- toYaml .Values.speaker.updateStrategy | nindent 4 }}
@@ -135,6 +138,9 @@ spec:
       labels:
         {{- include "metallb.selectorLabels" . | nindent 8 }}
         component: speaker
+        {{- range $key, $value := .Values.speaker.labels }}
+        {{ $key }}: {{ $value | quote }}
+        {{- end }}
     spec:
       {{- if .Values.speaker.runtimeClassName }}
       runtimeClassName: {{ .Values.speaker.runtimeClassName }}
@@ -152,6 +158,12 @@ spec:
           secret:
             secretName: {{ include "metallb.secretName" . }}
             defaultMode: 420
+      {{- end }}
+      {{- if .Values.speaker.excludeInterfaces.enabled }}
+        - name: metallb-excludel2
+          configMap:
+            defaultMode: 256
+            name: metallb-excludel2
       {{- end }}
       {{- if .Values.speaker.frr.enabled }}
         - name: frr-sockets
@@ -291,7 +303,7 @@ spec:
             - ALL
             add:
             - NET_RAW
-        {{- if or .Values.speaker.frr.enabled .Values.speaker.memberlist.enabled }}
+        {{- if or .Values.speaker.frr.enabled .Values.speaker.memberlist.enabled .Values.speaker.excludeInterfaces.enabled }}
         volumeMounts:
           {{- if .Values.speaker.memberlist.enabled }}
           - name: memberlist 
@@ -300,6 +312,10 @@ spec:
           {{- if .Values.speaker.frr.enabled }}
           - name: reloader
             mountPath: /etc/frr_reloader
+          {{- end }}
+          {{- if .Values.speaker.excludeInterfaces.enabled }}
+          - name: metallb-excludel2
+            mountPath: /etc/metallb
           {{- end }}
         {{- end }}
       {{- if .Values.speaker.frr.enabled }}

--- a/bindata/deployment/helm/values.schema.json
+++ b/bindata/deployment/helm/values.schema.json
@@ -322,6 +322,14 @@
                 }
               }
             },
+            "excludeInterfaces": {
+              "type": "object",
+              "properties": {
+                "enabled": {
+                  "type": "boolean"
+                }
+              }
+            },
             "updateStrategy": {
               "type": "object",
               "properties": {

--- a/bindata/deployment/helm/values.yaml
+++ b/bindata/deployment/helm/values.yaml
@@ -233,6 +233,7 @@ controller:
   runtimeClassName: ""
   affinity: {}
   podAnnotations: {}
+  labels: {}
   livenessProbe:
     enabled: true
     failureThreshold: 3
@@ -260,6 +261,8 @@ speaker:
     enabled: true
     mlBindPort: 7946
     mlSecretKeyPath: "/etc/ml_secret_key"
+  excludeInterfaces:
+    enabled: true
   image:
     repository: quay.io/metallb/speaker
     tag:
@@ -294,6 +297,7 @@ speaker:
   ## Selects which runtime class will be used by the pod.
   runtimeClassName: ""
   podAnnotations: {}
+  labels: {}
   livenessProbe:
     enabled: true
     failureThreshold: 3

--- a/bundle/manifests/metallb-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/metallb-operator.clusterserviceversion.yaml
@@ -273,7 +273,7 @@ metadata:
     categories: Networking
     certified: "false"
     containerImage: quay.io/metallb/metallb-operator
-    createdAt: "2023-03-16T10:08:32Z"
+    createdAt: "2023-03-22T10:26:14Z"
     description: An operator for deploying MetalLB on a kubernetes cluster.
     operators.operatorframework.io/builder: operator-sdk-v1.26.1
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v2
@@ -352,6 +352,12 @@ spec:
                 - get
                 - list
                 - watch
+            - apiGroups:
+                - ""
+              resources:
+                - nodes
+              verbs:
+                - list
             - apiGroups:
                 - ""
               resources:
@@ -871,6 +877,14 @@ spec:
                 - ""
               resources:
                 - secrets
+              verbs:
+                - get
+                - list
+                - watch
+            - apiGroups:
+                - ""
+              resources:
+                - configmaps
               verbs:
                 - get
                 - list

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -6,5 +6,5 @@ patchesStrategicMerge:
   - env.yaml
 images:
   - name: controller
-    newName: metallboperator
+    newName: quay.io/metallb/metallb-operator
     newTag: main

--- a/config/metallb_rbac/metallb-frr.yaml
+++ b/config/metallb_rbac/metallb-frr.yaml
@@ -129,6 +129,14 @@ rules:
       - list
       - watch
   - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
       - metallb.io
     resources:
       - addresspools
@@ -201,6 +209,12 @@ rules:
       - get
       - list
       - watch
+  - apiGroups:
+      - ""
+    resources:
+      - nodes
+    verbs:
+      - list
   - apiGroups:
       - ""
     resources:

--- a/config/metallb_rbac/metallb-native.yaml
+++ b/config/metallb_rbac/metallb-native.yaml
@@ -129,6 +129,14 @@ rules:
       - list
       - watch
   - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
       - metallb.io
     resources:
       - addresspools
@@ -201,6 +209,12 @@ rules:
       - get
       - list
       - watch
+  - apiGroups:
+      - ""
+    resources:
+      - nodes
+    verbs:
+      - list
   - apiGroups:
       - ""
     resources:

--- a/config/metallb_rbac/metallb-openshift.yaml
+++ b/config/metallb_rbac/metallb-openshift.yaml
@@ -218,6 +218,12 @@ rules:
   - apiGroups:
       - ""
     resources:
+      - nodes
+    verbs:
+      - list
+  - apiGroups:
+      - ""
+    resources:
       - services/status
     verbs:
       - update

--- a/hack/common.sh
+++ b/hack/common.sh
@@ -17,7 +17,7 @@ export PATH=$PATH:$GOPATH/bin
 
 mkdir -p _cache
 
-export METALLB_COMMIT_ID="790e6e98187e523edf715d4b0a60e38baca712fd"
+export METALLB_COMMIT_ID="7b6d91db081433e9121d68b6e88e316394dcbc4c"
 export METALLB_PATH=_cache/metallb
 
 export METALLB_SC_FILE=$(dirname "$0")/securityContext.yaml

--- a/pkg/helm/testdata/ocp-metrics-speaker.golden
+++ b/pkg/helm/testdata/ocp-metrics-speaker.golden
@@ -146,6 +146,10 @@
                             {
                                 "mountPath": "/etc/frr_reloader",
                                 "name": "reloader"
+                            },
+                            {
+                                "mountPath": "/etc/metallb",
+                                "name": "metallb-excludel2"
                             }
                         ]
                     },
@@ -419,6 +423,13 @@
                             "defaultMode": 420,
                             "secretName": "metallb-memberlist"
                         }
+                    },
+                    {
+                        "configMap": {
+                            "defaultMode": 256,
+                            "name": "metallb-excludel2"
+                        },
+                        "name": "metallb-excludel2"
                     },
                     {
                         "emptyDir": {},

--- a/pkg/helm/testdata/vanilla-metrics-speaker.golden
+++ b/pkg/helm/testdata/vanilla-metrics-speaker.golden
@@ -146,6 +146,10 @@
                             {
                                 "mountPath": "/etc/frr_reloader",
                                 "name": "reloader"
+                            },
+                            {
+                                "mountPath": "/etc/metallb",
+                                "name": "metallb-excludel2"
                             }
                         ]
                     },
@@ -401,6 +405,13 @@
                             "defaultMode": 420,
                             "secretName": "metallb-memberlist"
                         }
+                    },
+                    {
+                        "configMap": {
+                            "defaultMode": 256,
+                            "name": "metallb-excludel2"
+                        },
+                        "name": "metallb-excludel2"
                     },
                     {
                         "emptyDir": {},


### PR DESCRIPTION
Bump metallb to the latest version mainly due to changes
in the cluster role of the controller. See https://github.com/metallb/metallb/pull/1820.