### PR TITLE
Bump MetalLB commit reference

### DIFF
--- a/.github/workflows/metallb_e2e.yml
+++ b/.github/workflows/metallb_e2e.yml
@@ -49,7 +49,7 @@ jobs:
         with:
           repository: metallb/metallb
           path: metallb
-          ref: 7b6d91db081433e9121d68b6e88e316394dcbc4c
+          ref: 1424dbaef1313b8bb20df136e8eacd2dbacdae02
       - name: Checkout MetalLB v0.12
         uses: actions/checkout@v2
         with:

--- a/bindata/deployment/helm/templates/speaker.yaml
+++ b/bindata/deployment/helm/templates/speaker.yaml
@@ -413,7 +413,7 @@ spec:
       {{- if .Values.prometheus.secureMetricsPort }}
       - name: kube-rbac-proxy
         image: {{ .Values.prometheus.rbacProxy.repository }}:{{ .Values.prometheus.rbacProxy.tag }}
-        imagePullPolicy: IfNotPresent
+        imagePullPolicy: {{ .Values.prometheus.rbacProxy.pullPolicy }}
         args:
           - --logtostderr
           - --secure-listen-address=:{{ .Values.prometheus.secureMetricsPort }}
@@ -446,7 +446,7 @@ spec:
       {{- if .Values.speaker.frr.secureMetricsPort }}
       - name: kube-rbac-proxy-frr
         image: {{ .Values.prometheus.rbacProxy.repository }}:{{ .Values.prometheus.rbacProxy.tag | default .Chart.AppVersion }}
-        imagePullPolicy: IfNotPresent
+        imagePullPolicy: {{ .Values.prometheus.rbacProxy.pullPolicy }}
         args:
           - --logtostderr
           - --secure-listen-address=:{{ .Values.speaker.frr.secureMetricsPort }}

--- a/hack/common.sh
+++ b/hack/common.sh
@@ -17,7 +17,7 @@ export PATH=$PATH:$GOPATH/bin
 
 mkdir -p _cache
 
-export METALLB_COMMIT_ID="7b6d91db081433e9121d68b6e88e316394dcbc4c"
+export METALLB_COMMIT_ID="1424dbaef1313b8bb20df136e8eacd2dbacdae02"
 export METALLB_PATH=_cache/metallb
 
 export METALLB_SC_FILE=$(dirname "$0")/securityContext.yaml

--- a/pkg/helm/testdata/ocp-metrics-speaker.golden
+++ b/pkg/helm/testdata/ocp-metrics-speaker.golden
@@ -275,7 +275,7 @@
                             }
                         ],
                         "image": "gcr.io/kubebuilder/kube-rbac-proxy:v0.12.0",
-                        "imagePullPolicy": "IfNotPresent",
+                        "imagePullPolicy": null,
                         "name": "kube-rbac-proxy",
                         "ports": [
                             {
@@ -318,7 +318,7 @@
                             }
                         ],
                         "image": "gcr.io/kubebuilder/kube-rbac-proxy:v0.12.0",
-                        "imagePullPolicy": "IfNotPresent",
+                        "imagePullPolicy": null,
                         "name": "kube-rbac-proxy-frr",
                         "ports": [
                             {

--- a/pkg/helm/testdata/vanilla-metrics-speaker.golden
+++ b/pkg/helm/testdata/vanilla-metrics-speaker.golden
@@ -273,7 +273,7 @@
                             }
                         ],
                         "image": "myrepo/image:mytag",
-                        "imagePullPolicy": "IfNotPresent",
+                        "imagePullPolicy": null,
                         "name": "kube-rbac-proxy",
                         "ports": [
                             {
@@ -307,7 +307,7 @@
                             }
                         ],
                         "image": "myrepo/image:mytag",
-                        "imagePullPolicy": "IfNotPresent",
+                        "imagePullPolicy": null,
                         "name": "kube-rbac-proxy-frr",
                         "ports": [
                             {


### PR DESCRIPTION
This commit bumps the MetalLB reference:
From:
7b6d91d (Make localPref uniform among updates) 21/03/2023

To:
1424dba (Add an assignement test that uses the namespace labels) 31/03/2023