### PR TITLE
Add Periodic MetalLB Bump workflow

### DIFF
--- a/.github/workflows/bump_metallb.yml
+++ b/.github/workflows/bump_metallb.yml
@@ -1,0 +1,72 @@
+name: Periodic MetalLB Bump
+on:
+  schedule:
+    # every day at 7am & 7pm (GMT+2)
+    - cron: "0 5,17 * * *"
+jobs:
+  bump-metallb-and-create-pr:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Latest Metal LB Operator
+        uses: actions/checkout@v3
+        with:
+          path: metallboperator
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          repository: metallb/metallb
+          path: metallb
+          fetch-depth: 0
+      - name: Get current metallb commit hash
+        id: old-metallb
+        run: |
+          source metallboperator/hack/common.sh
+          echo "commit_sha=$METALLB_COMMIT_ID" >> $GITHUB_OUTPUT
+      - name: Get old commit info
+        id: old-commit-info
+        run: |
+          cd metallb
+          echo "commit_title=$(git log -1 --pretty=%s ${{ steps.old-metallb.outputs.commit_sha }})" >> $GITHUB_OUTPUT
+          echo "commit_date=$(git log -n1 --pretty='format:%cd' --date=format:'%Y-%m-%d' ${{ steps.old-metallb.outputs.commit_sha }})" >> $GITHUB_OUTPUT
+      - name: Get new commit info
+        id: new-commit-info
+        run: |
+          cd metallb
+          echo "commit_sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
+          echo "commit_title=$(git log -1 --pretty=%s HEAD)" >> $GITHUB_OUTPUT
+          echo "commit_date=$(git log -n1 --pretty='format:%cd' --date=format:'%Y-%m-%d' HEAD)" >> $GITHUB_OUTPUT
+      - name: Check if there are changes
+        id: check-for-changes
+        run: |
+          if [[ ${{ steps.old-metallb.outputs.commit_sha }} == ${{ steps.new-commit-info.outputs.commit_sha }} ]]; then
+            echo "has_changes=false" >> $GITHUB_OUTPUT
+          else
+            echo "has_changes=true" >> $GITHUB_OUTPUT
+          fi
+      - uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Bump metallb
+        if: ${{ steps.check-for-changes.outputs.has_changes == 'true' }}
+        run: make bump_metallb
+      - name: Create pull request
+        if: ${{ steps.check-for-changes.outputs.has_changes == 'true'}}
+        uses: peter-evans/create-pull-request@v5
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: |
+            Bump MetalLB
+
+            This commit bumps MetalLB:
+            from: ${{ steps.old-metallb.outputs.commit_sha }}
+            ${{ steps.old-commit-info.outputs.commit_title }} (${{ steps.old-commit-info.outputs.commit_date }})
+            
+            to:  ${{ steps.new-commit-info.outputs.commit_sha }}
+            ${{ steps.new-commit-info.outputs.commit_title }} (${{ steps.new-commit-info.outputs.commit_date }})
+          author: github-actions[bot] <noreply@github.com>
+          committer: github-actions[bot] <noreply@github.com>
+          title: "Bump MetalLB"
+          branch: "bumpmetallb"
+          delete-branch: true
+          base: "main"
+          

--- a/.github/workflows/metallb_e2e.yml
+++ b/.github/workflows/metallb_e2e.yml
@@ -44,12 +44,15 @@ jobs:
         run: |
           make manifests
           git diff --exit-code
+      - name: Read metallb ref
+        id: metallb_ref
+        run: echo "content=$(cat ./hack/metallb_ref.txt)" >> $GITHUB_OUTPUT
       - name: Checkout MetalLB
         uses: actions/checkout@v2
         with:
           repository: metallb/metallb
           path: metallb
-          ref: 1424dbaef1313b8bb20df136e8eacd2dbacdae02
+          ref: "${{ steps.metallb_ref.outputs.content }}"
       - name: Checkout MetalLB v0.12
         uses: actions/checkout@v2
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ testbin/
 
 # Dependency directories (remove the comment below to include it)
 # vendor/
+
+# Ignore .idea files
+.idea/

--- a/Makefile
+++ b/Makefile
@@ -256,7 +256,6 @@ bump_metallb: ## Bumps metallb commit ID and creates manifests. It also validate
 	hack/bump_metallb.sh
 	$(MAKE) bin
 	$(MAKE) bundle-release
-	$(MAKE) test
 
 check_generated: ## Checks if there are any different with the current checkout
 	@echo "Checking generated files"

--- a/hack/bump_metallb.sh
+++ b/hack/bump_metallb.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 HASH=`git ls-remote https://github.com/metallb/metallb | grep refs/heads/main | cut -f 1`
-sed -i "s/export METALLB_COMMIT_ID=.*/export METALLB_COMMIT_ID=\"$HASH\"/g" hack/common.sh
+echo $HASH > hack/metallb_ref.txt

--- a/hack/common.sh
+++ b/hack/common.sh
@@ -17,7 +17,7 @@ export PATH=$PATH:$GOPATH/bin
 
 mkdir -p _cache
 
-export METALLB_COMMIT_ID="1424dbaef1313b8bb20df136e8eacd2dbacdae02"
+export METALLB_COMMIT_ID=$(cat hack/metallb_ref.txt)
 export METALLB_PATH=_cache/metallb
 
 export METALLB_SC_FILE=$(dirname "$0")/securityContext.yaml

--- a/hack/generate-metallb-manifests.sh
+++ b/hack/generate-metallb-manifests.sh
@@ -24,9 +24,6 @@ curl ${FRR_MANIFESTS_URL} -o _cache/${FRR_MANIFESTS_FILE}
 # Generate metallb-frr rbac manifests
 yq e '. | select(.kind == "Role" or .kind == "ClusterRole" or .kind == "RoleBinding" or .kind == "ClusterRoleBinding" or .kind == "ServiceAccount")' _cache/${FRR_MANIFESTS_FILE} > config/metallb_rbac/${FRR_MANIFESTS_FILE}
 
-# Update MetalLB's E2E lane to clone the same commit as the manifests.
-yq e --inplace ".jobs.main.steps[] |= select(.name==\"Checkout MetalLB\").with.ref=\"${METALLB_COMMIT_ID}\"" .github/workflows/metallb_e2e.yml
-
 fetch_metallb
 
 # we want to preserve the metallb crd

--- a/hack/metallb_ref.txt
+++ b/hack/metallb_ref.txt
@@ -1,0 +1,1 @@
+1424dbaef1313b8bb20df136e8eacd2dbacdae02


### PR DESCRIPTION
This commit adds a new workflow to periodically align
with the upstream MetalLB repository.

This is setup to run daily at 7AM and 7PM (GMT+2 clock),
run the make `bump_metallb` and if differences exist,
then open a PR with the bump,
and on the commit message added details of the old commit,
and the new commit, just so it will be easier
for developers to maintain and keep track of changes.

Created metallb_ref.txt as the single source of truth for
the metallb commit hash.

Also deleted the `make test` from the bump_metallb, because we want
the workflow not to fail and to open PR even if the unit tests are
failing, so we could catch and fix that.

Notice: Every time this workflow runs it fetches latest metallb
and force-push to already open PR under the "bumpmetallb" branch.

Signed-off-by: liornoy <lnoy@redhat.com>
