### PR TITLE
Enable configuration of loadbalancer class

### DIFF
--- a/api/v1beta1/metallb_types.go
+++ b/api/v1beta1/metallb_types.go
@@ -59,6 +59,11 @@ type MetalLBSpec struct {
 	// +kubebuilder:validation:Enum=all;debug;info;warn;error;none
 	LogLevel MetalLBLogLevel `json:"logLevel,omitempty"`
 
+	// The loadBalancerClass spec attribute that the MetalLB controller should
+	// be watching for
+	// +optional
+	LoadBalancerClass string `json:"loadBalancerClass,omitempty"`
+
 	// node selector applied to MetalLB controller deployment.
 	// +optional
 	ControllerNodeSelector map[string]string `json:"controllerNodeSelector,omitempty"`

--- a/api/v1beta1/metallb_types.go
+++ b/api/v1beta1/metallb_types.go
@@ -60,8 +60,11 @@ type MetalLBSpec struct {
 	LogLevel MetalLBLogLevel `json:"logLevel,omitempty"`
 
 	// The loadBalancerClass spec attribute that the MetalLB controller should
-	// be watching for
+	// be watching for. must be a label-style identifier, with an optional
+	// prefix such as "internal-vip" or "example.com/internal-vip". Unprefixed
+	// names are reserved for end-users.
 	// +optional
+	// +kubebuilder:validation:Pattern=`^([a-z0-9A-Z]([\w.\-]*[a-z0-9A-Z])?/)?[a-z0-9A-Z]([\w.\-]*[a-z0-9A-Z])?$`
 	LoadBalancerClass string `json:"loadBalancerClass,omitempty"`
 
 	// node selector applied to MetalLB controller deployment.

--- a/bin/metallb-operator.yaml
+++ b/bin/metallb-operator.yaml
@@ -2279,7 +2279,10 @@ spec:
                 type: string
               loadBalancerClass:
                 description: The loadBalancerClass spec attribute that the MetalLB
-                  controller should be watching for
+                  controller should be watching for. must be a label-style identifier,
+                  with an optional prefix such as "internal-vip" or "example.com/internal-vip".
+                  Unprefixed names are reserved for end-users.
+                pattern: ^([a-z0-9A-Z]([\w.\-]*[a-z0-9A-Z])?/)?[a-z0-9A-Z]([\w.\-]*[a-z0-9A-Z])?$
                 type: string
               logLevel:
                 description: 'Define the verbosity of the controller and the speaker

--- a/bin/metallb-operator.yaml
+++ b/bin/metallb-operator.yaml
@@ -2277,6 +2277,10 @@ spec:
                 description: Foo is an example field of MetalLB. Edit MetalLB_types.go
                   to remove/update
                 type: string
+              loadBalancerClass:
+                description: The loadBalancerClass spec attribute that the MetalLB
+                  controller should be watching for
+                type: string
               logLevel:
                 description: 'Define the verbosity of the controller and the speaker
                   logging. Allowed values are: all, debug, info, warn, error, none.

--- a/bundle/manifests/metallb-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/metallb-operator.clusterserviceversion.yaml
@@ -273,7 +273,7 @@ metadata:
     categories: Networking
     certified: "false"
     containerImage: quay.io/metallb/metallb-operator
-    createdAt: "2023-03-22T10:26:14Z"
+    createdAt: "2023-04-28T16:27:21Z"
     description: An operator for deploying MetalLB on a kubernetes cluster.
     operators.operatorframework.io/builder: operator-sdk-v1.26.1
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v2

--- a/bundle/manifests/metallb.io_metallbs.yaml
+++ b/bundle/manifests/metallb.io_metallbs.yaml
@@ -995,6 +995,13 @@ spec:
                 description: Foo is an example field of MetalLB. Edit MetalLB_types.go
                   to remove/update
                 type: string
+              loadBalancerClass:
+                description: The loadBalancerClass spec attribute that the MetalLB
+                  controller should be watching for. must be a label-style identifier,
+                  with an optional prefix such as "internal-vip" or "example.com/internal-vip".
+                  Unprefixed names are reserved for end-users.
+                pattern: ^([a-z0-9A-Z]([\w.\-]*[a-z0-9A-Z])?/)?[a-z0-9A-Z]([\w.\-]*[a-z0-9A-Z])?$
+                type: string
               logLevel:
                 description: 'Define the verbosity of the controller and the speaker
                   logging. Allowed values are: all, debug, info, warn, error, none.

--- a/config/crd/bases/metallb.io_metallbs.yaml
+++ b/config/crd/bases/metallb.io_metallbs.yaml
@@ -996,6 +996,10 @@ spec:
                 description: Foo is an example field of MetalLB. Edit MetalLB_types.go
                   to remove/update
                 type: string
+              loadBalancerClass:
+                description: The loadBalancerClass spec attribute that the MetalLB
+                  controller should be watching for
+                type: string
               logLevel:
                 description: 'Define the verbosity of the controller and the speaker
                   logging. Allowed values are: all, debug, info, warn, error, none.

--- a/config/crd/bases/metallb.io_metallbs.yaml
+++ b/config/crd/bases/metallb.io_metallbs.yaml
@@ -998,7 +998,10 @@ spec:
                 type: string
               loadBalancerClass:
                 description: The loadBalancerClass spec attribute that the MetalLB
-                  controller should be watching for
+                  controller should be watching for. must be a label-style identifier,
+                  with an optional prefix such as "internal-vip" or "example.com/internal-vip".
+                  Unprefixed names are reserved for end-users.
+                pattern: ^([a-z0-9A-Z]([\w.\-]*[a-z0-9A-Z])?/)?[a-z0-9A-Z]([\w.\-]*[a-z0-9A-Z])?$
                 type: string
               logLevel:
                 description: 'Define the verbosity of the controller and the speaker

--- a/config/samples/demo/metallb-advanced-config.yaml
+++ b/config/samples/demo/metallb-advanced-config.yaml
@@ -1,8 +1,8 @@
 apiVersion: node.k8s.io/v1
 kind: RuntimeClass
 metadata:
-  name: myclass 
-handler: myconfiguration 
+  name: myclass
+handler: myconfiguration
 ---
 apiVersion: scheduling.k8s.io/v1
 kind: PriorityClass
@@ -19,6 +19,7 @@ spec:
   logLevel: debug
   nodeSelector:
     feature.node.kubernetes.io/metalLB.capable: 'true'
+  loadBalancerClass: 'metallb.universe.tf/metallb'
   speakerTolerations:
   - key: "Example"
     operator: "Exists"

--- a/config/samples/demo/metallb.yaml
+++ b/config/samples/demo/metallb.yaml
@@ -6,6 +6,7 @@ metadata:
 spec:
   nodeSelector:
     feature.node.kubernetes.io/metalLB.capable: 'true'
+  loadBalancerClass: 'metallb.universe.tf/metallb'
   speakerTolerations:
   - key: "Example"
     operator: "Exists"

--- a/pkg/helm/config.go
+++ b/pkg/helm/config.go
@@ -49,9 +49,16 @@ type imageInfo struct {
 }
 
 func patchToChartValues(c *chartConfig, crdConfig *metallbv1beta1.MetalLB, withPrometheus bool, valueMap map[string]interface{}) {
+	withGeneralValues(c, crdConfig, valueMap)
 	withPrometheusValues(c, valueMap)
 	withControllerValues(c, crdConfig, valueMap)
 	withSpeakerValues(c, crdConfig, valueMap)
+}
+
+func withGeneralValues(c *chartConfig, crdConfig *metallbv1beta1.MetalLB, valueMap map[string]interface{}) {
+	if crdConfig.Spec.LoadBalancerClass != "" {
+		valueMap["loadBalancerClass"] = crdConfig.Spec.LoadBalancerClass
+	}
 }
 
 func withPrometheusValues(c *chartConfig, valueMap map[string]interface{}) {

--- a/pkg/helm/helm_test.go
+++ b/pkg/helm/helm_test.go
@@ -85,6 +85,7 @@ func TestParseMetalLBChartWithCustomValues(t *testing.T) {
 			Effect:   v1.TaintEffectNoExecute,
 		},
 	}
+	loadBalancerClass := "metallb.universe.tf/metallb"
 	controllerNodeSelector := map[string]string{"kubernetes.io/os": "linux", "node-role.kubernetes.io/worker": "true"}
 	controllerConfig := &metallbv1beta1.Config{
 		PriorityClassName: "high-priority",
@@ -118,6 +119,7 @@ func TestParseMetalLBChartWithCustomValues(t *testing.T) {
 			ControllerTolerations:  controllerTolerations,
 			ControllerConfig:       controllerConfig,
 			SpeakerConfig:          speakerConfig,
+			LoadBalancerClass:      loadBalancerClass,
 		},
 	}
 
@@ -163,6 +165,7 @@ func TestParseMetalLBChartWithCustomValues(t *testing.T) {
 				if container.Name == "speaker" {
 					g.Expect(container.Resources).NotTo(BeNil())
 					g.Expect(container.Resources.Limits.Cpu().MilliValue()).To(Equal(int64(200)))
+					g.Expect(container.Args).To(ContainElement("--lb-class=metallb.universe.tf/metallb"))
 					speakerContainerFound = true
 				}
 			}


### PR DESCRIPTION
Add the ability to set a `loadBalancerClass` value on the `MetalLB` CRD. The `Service.Spec.LoadBalancerClass` field reached GA in Kubernetes 1.24 and support was introduced in MetalLB in v0.13 [1][1].

[1]: https://github.com/metallb/metallb/pull/1417

Signed-off-by: Stephen Finucane <stephenfin@redhat.com>
Closes: #267
