### PR TITLE
Fix bump_metallb workflow

### DIFF
--- a/.github/workflows/bump_metallb.yml
+++ b/.github/workflows/bump_metallb.yml
@@ -20,8 +20,7 @@ jobs:
       - name: Get current metallb commit hash
         id: old-metallb
         run: |
-          source metallboperator/hack/common.sh
-          echo "commit_sha=$METALLB_COMMIT_ID" >> $GITHUB_OUTPUT
+          echo "commit_sha=$(cat metallboperator/hack/metallb_ref.txt)" >> $GITHUB_OUTPUT
       - name: Get old commit info
         id: old-commit-info
         run: |


### PR DESCRIPTION
This commit makes the "old-metallb" step, on the
bump_metallb workflow, to cat the metallb_ref.txt
file directly instead of sourcing the common.sh
in order to query the old metallb commit hash.