### PR TITLE
Enable race detection in unit tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ ENVTEST_ASSETS_DIR=$(shell pwd)/testbin
 test: generate fmt vet manifests ## Run unit and integration tests
 	mkdir -p ${ENVTEST_ASSETS_DIR}
 	test -f ${ENVTEST_ASSETS_DIR}/setup-envtest.sh || curl -sSLo ${ENVTEST_ASSETS_DIR}/setup-envtest.sh https://raw.githubusercontent.com/kubernetes-sigs/controller-runtime/v0.8.3/hack/setup-envtest.sh
-	source ${ENVTEST_ASSETS_DIR}/setup-envtest.sh; fetch_envtest_tools $(ENVTEST_ASSETS_DIR); setup_envtest_env $(ENVTEST_ASSETS_DIR); go test ./... -coverprofile cover.out
+	source ${ENVTEST_ASSETS_DIR}/setup-envtest.sh; fetch_envtest_tools $(ENVTEST_ASSETS_DIR); setup_envtest_env $(ENVTEST_ASSETS_DIR); go test -race ./... -coverprofile cover.out
 
 all: manager ## Default make target if no options specified
 


### PR DESCRIPTION
This pull request enables race detection in unit tests by modifying the Makefile. The test configuration is updated to include the '-race' flag, allowing thorough race detection during testing. 

Race detection can help identifying potential data race conditions, which can lead to hard-to-debug issues in concurrent code. By enabling race detection in our unit tests, we can detect and address these race conditions, ensuring the reliability and stability of our code. (for further reference view: https://go.dev/doc/articles/race_detector)