### PR TITLE
Fix metallb controller log message

### DIFF
--- a/controllers/metallb_controller.go
+++ b/controllers/metallb_controller.go
@@ -110,7 +110,7 @@ func (r *MetalLBReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 			}
 		}
 		if err := status.Update(context.TODO(), r.Client, instance, condition, errorMsg, wrappedErrMsg); err != nil {
-			logger.Error(err, "Failed to update metallb status", "Desired status", status.ConditionAvailable)
+			logger.Error(err, "Failed to update metallb status", "Desired status", condition)
 		}
 	}
 	return result, err

--- a/hack/kind-cluster-with-registry.sh
+++ b/hack/kind-cluster-with-registry.sh
@@ -15,7 +15,7 @@ if [ "${running}" != 'true' ]; then
 fi
 
 # create a cluster with the local registry enabled in containerd
-cat <<EOF | kind create cluster --image kindest/node:v1.24.0 --name "${KIND_CLUSTER_NAME}" --config=-
+cat <<EOF | kind create cluster --image kindest/node:v1.27.3 --name "${KIND_CLUSTER_NAME}" --config=-
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 nodes:

--- a/hack/kind-cluster-without-registry.sh
+++ b/hack/kind-cluster-without-registry.sh
@@ -4,7 +4,7 @@ set -o errexit
 # desired cluster name; default is "kind"
 KIND_CLUSTER_NAME="${KIND_CLUSTER_NAME:-kind}"
 
-cat <<EOF | kind create cluster --image kindest/node:v1.24.0 --config=-
+cat <<EOF | kind create cluster --image kindest/node:v1.27.3 --config=-
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 nodes:

--- a/hack/kind-multi-node-cluster-without-registry.sh
+++ b/hack/kind-multi-node-cluster-without-registry.sh
@@ -4,7 +4,7 @@ set -o errexit
 # desired cluster name; default is "kind"
 KIND_CLUSTER_NAME="${KIND_CLUSTER_NAME:-kind}"
 
-cat <<EOF | kind create cluster --image kindest/node:v1.24.0 --config=-
+cat <<EOF | kind create cluster --image kindest/node:v1.27.3 --config=-
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 nodes:


### PR DESCRIPTION
This commit fixes the metallb controller log message and replaces the hard-coded "ConditionAvailable" with the condition var.

This is because we might fail to update the status to ConditionProgressing, but still see in logs ConditionAvailable.

fixes #360 