### PR TITLE
Add action-bot signature in commit message

### DIFF
--- a/.github/workflows/bump_metallb.yml
+++ b/.github/workflows/bump_metallb.yml
@@ -62,6 +62,8 @@ jobs:
             
             to:  ${{ steps.new-commit-info.outputs.commit_sha }}
             ${{ steps.new-commit-info.outputs.commit_title }} (${{ steps.new-commit-info.outputs.commit_date }})
+
+            Signed-off-by: github-actions[bot] <noreply@github.com>
           author: github-actions[bot] <noreply@github.com>
           committer: github-actions[bot] <noreply@github.com>
           title: "Bump MetalLB"


### PR DESCRIPTION
Add "Signed-off-by: github-actions[bot] <noreply@github.com>" in the bump_metallb flow to satisfy the DCO check.