### PR TITLE
Remove "quiet" flag from git diff

### DIFF
--- a/.github/workflows/olm.yml
+++ b/.github/workflows/olm.yml
@@ -48,7 +48,7 @@ jobs:
     - name: Verify release bundle manifests
       run: |
         make bundle-release
-        git diff --exit-code --quiet -I'^    createdAt: ' bundle 
+        git diff --exit-code -I'^    createdAt: ' bundle
 
     - name: Create and set up K8s Kind Cluster
       run: |

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -38,7 +38,7 @@ jobs:
       - name: Verify release bundle manifests
         run: |
           make bundle-release
-          git diff --exit-code --quiet -I'^    createdAt: ' bundle
+          git diff --exit-code -I'^    createdAt: ' bundle
 
       - name: Create and set up K8s Kind Cluster
         run: |


### PR DESCRIPTION
We are running git diff as part of the CI workflow to verify the bundle is aligned.

However, when a diff exists we don't see it because of the --quiet flag, and this hides the problem.