### PR TITLE
Makefile: separate the operator build from bundle build

### DIFF
--- a/.github/workflows/olm.yml
+++ b/.github/workflows/olm.yml
@@ -44,16 +44,20 @@ jobs:
       run: |
         make fmt
         git diff --exit-code
-  
+
     - name: Verify release bundle manifests
       run: |
         make bundle-release
-        git diff --exit-code --quiet -I'^    createdAt: ' bundle 
+        git diff --exit-code --quiet -I'^    createdAt: ' bundle
 
     - name: Create and set up K8s Kind Cluster
       run: |
         ./hack/kind-cluster-with-registry.sh
         make deploy-olm
+
+    - name: Build operator image
+      run: |
+        make build-and-push-operator REPO=localhost:5000
 
     - name: Build bundle image
       run: |


### PR DESCRIPTION
When we want to test a custom bundle, we might not need to rebuild the operator. Because of this we separate the two steps. Also, we allow to aim at a custom dockerfile for the bundle.