### PR TITLE
Remove unused metallb image field from spec

### DIFF
--- a/api/v1beta1/metallb_types.go
+++ b/api/v1beta1/metallb_types.go
@@ -41,9 +41,6 @@ type MetalLBSpec struct {
 	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
 
-	// Foo is an example field of MetalLB. Edit MetalLB_types.go to remove/update
-	MetalLBImage string `json:"image,omitempty"`
-
 	// node selector applied to MetalLB speaker daemonset.
 	// +optional
 	SpeakerNodeSelector map[string]string `json:"nodeSelector,omitempty"`

--- a/bin/metallb-operator.yaml
+++ b/bin/metallb-operator.yaml
@@ -2275,10 +2275,6 @@ spec:
                       type: string
                   type: object
                 type: array
-              image:
-                description: Foo is an example field of MetalLB. Edit MetalLB_types.go
-                  to remove/update
-                type: string
               loadBalancerClass:
                 description: The loadBalancerClass spec attribute that the MetalLB
                   controller should be watching for. must be a label-style identifier,

--- a/bundle/manifests/metallb.io_metallbs.yaml
+++ b/bundle/manifests/metallb.io_metallbs.yaml
@@ -991,10 +991,6 @@ spec:
                       type: string
                   type: object
                 type: array
-              image:
-                description: Foo is an example field of MetalLB. Edit MetalLB_types.go
-                  to remove/update
-                type: string
               loadBalancerClass:
                 description: The loadBalancerClass spec attribute that the MetalLB
                   controller should be watching for. must be a label-style identifier,

--- a/config/crd/bases/metallb.io_metallbs.yaml
+++ b/config/crd/bases/metallb.io_metallbs.yaml
@@ -992,10 +992,6 @@ spec:
                       type: string
                   type: object
                 type: array
-              image:
-                description: Foo is an example field of MetalLB. Edit MetalLB_types.go
-                  to remove/update
-                type: string
               loadBalancerClass:
                 description: The loadBalancerClass spec attribute that the MetalLB
                   controller should be watching for. must be a label-style identifier,


### PR DESCRIPTION
Removes the image field from the MetalLB resource
as this is an unused field.

fix #370 