### PR TITLE
rewrite func getImageNameTag for supporting registries with port

### DIFF
--- a/pkg/helm/config.go
+++ b/pkg/helm/config.go
@@ -330,9 +330,15 @@ func valueWithDefault(name string, def int) (int, error) {
 }
 
 func getImageNameTag(envValue string) (string, string) {
-	img := strings.Split(envValue, ":")
+	pos := strings.LastIndex(envValue, "/")
+	// We assume the last ":" shows up right before the image's tag, and the last "/" just before the image's name.
+	// Multiple ":" can be present when the port of the registry is specified and we should include
+	// it as part of the repo's url.
+	img := strings.Split(envValue[pos+1:], ":")
+	repoPath := envValue[:pos+1]
+
 	if len(img) == 1 {
-		return img[0], ""
+		return repoPath + img[0], ""
 	}
-	return img[0], img[1]
+	return repoPath + img[0], img[1]
 }

--- a/pkg/helm/config_test.go
+++ b/pkg/helm/config_test.go
@@ -1,0 +1,53 @@
+package helm
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestGetImageNameTag(t *testing.T) {
+	tests := []struct {
+		input         string
+		expectedImage string
+		expectedTag   string
+	}{
+		{
+			input:         "quay.io/metallb/speaker:v0.13.9",
+			expectedImage: "quay.io/metallb/speaker",
+			expectedTag:   "v0.13.9",
+		},
+		{
+			input:         "quay.io:5000/metallb/speaker:v0.13.9",
+			expectedImage: "quay.io:5000/metallb/speaker",
+			expectedTag:   "v0.13.9",
+		},
+		{
+			input:         "quay.io/metallb/speaker",
+			expectedImage: "quay.io/metallb/speaker",
+			expectedTag:   "",
+		},
+		{
+			input:         "quay.io:5000/metallb/speaker",
+			expectedImage: "quay.io:5000/metallb/speaker",
+			expectedTag:   "",
+		},
+		{
+			input:         "speaker:v0.13.9",
+			expectedImage: "speaker",
+			expectedTag:   "v0.13.9",
+		},
+		{
+			input:         "speaker",
+			expectedImage: "speaker",
+			expectedTag:   "",
+		},
+	}
+
+	g := NewGomegaWithT(t)
+	for _, test := range tests {
+		img, tag := getImageNameTag(test.input)
+		g.Expect(img).To(Equal(test.expectedImage))
+		g.Expect(tag).To(Equal(test.expectedTag))
+	}
+}


### PR DESCRIPTION
To make operator works with image's path in format  myregistry.local.com:5000/metallb/controller:v0.13.9

