### PR TITLE
Move the k8sreporter dump into FailHandler and make dir for the reports

### DIFF
--- a/test/consts/const.go
+++ b/test/consts/const.go
@@ -1,6 +1,10 @@
 package consts
 
-import "github.com/metallb/metallb-operator/pkg/apply"
+import (
+	"time"
+
+	"github.com/metallb/metallb-operator/pkg/apply"
+)
 
 const (
 	// MetalLBOperatorDeploymentName contains the name of the MetalLB Operator deployment
@@ -19,4 +23,6 @@ const (
 	MetalLBConfigMapName = apply.MetalLBConfigMap
 	// DefaultOperatorNameSpace is the default operator namespace
 	DefaultOperatorNameSpace = "metallb-system"
+	// LogsExtractDuration represents how much in the past to fetch the logs from
+	LogsExtractDuration = 10 * time.Minute
 )

--- a/test/e2e/functional/e2e_test.go
+++ b/test/e2e/functional/e2e_test.go
@@ -57,7 +57,8 @@ func TestE2E(t *testing.T) {
 
 	if *reportPath != "" {
 		kubeconfig := os.Getenv("KUBECONFIG")
-		r = k8sreporter.New(kubeconfig, *reportPath, OperatorNameSpace)
+		reportPath := path.Join(*reportPath, "metallb_failure_report.log")
+		r = k8sreporter.New(kubeconfig, reportPath, OperatorNameSpace)
 	}
 
 	RunSpecs(t, "Metallb Operator E2E Suite", reporterConfig)

--- a/test/e2e/functional/e2e_test.go
+++ b/test/e2e/functional/e2e_test.go
@@ -8,10 +8,8 @@ import (
 	"os"
 	"path"
 	"testing"
-	"time"
 
 	. "github.com/onsi/ginkgo/v2"
-	"github.com/onsi/ginkgo/v2/types"
 	. "github.com/onsi/gomega"
 
 	"github.com/metallb/metallb-operator/test/consts"
@@ -36,7 +34,19 @@ func init() {
 }
 
 func TestE2E(t *testing.T) {
-	RegisterFailHandler(Fail)
+	// We want to collect logs before any resource is deleted in AfterEach, so we register the global fail handler
+	// in a way such that the reporter's Dump is always called before the default Fail.
+	RegisterFailHandler(func(message string, callerSkip ...int) {
+		if r != nil {
+			r.Dump(consts.LogsExtractDuration, CurrentSpecReport().FullText())
+		}
+
+		// Ensure failing line location is not affected by this wrapper
+		for i := range callerSkip {
+			callerSkip[i]++
+		}
+		Fail(message, callerSkip...)
+	})
 
 	_, reporterConfig := GinkgoConfiguration()
 
@@ -52,13 +62,3 @@ func TestE2E(t *testing.T) {
 
 	RunSpecs(t, "Metallb Operator E2E Suite", reporterConfig)
 }
-
-var _ = ReportAfterEach(func(specReport types.SpecReport) {
-	if specReport.Failed() == false {
-		return
-	}
-
-	if r != nil {
-		r.Dump(10*time.Minute, specReport.FullText())
-	}
-})

--- a/test/e2e/k8sreporter/reporter.go
+++ b/test/e2e/k8sreporter/reporter.go
@@ -3,7 +3,9 @@
 package k8sreporter
 
 import (
+	"errors"
 	"log"
+	"os"
 
 	"github.com/openshift-kni/k8sreporter"
 	corev1 "k8s.io/api/core/v1"
@@ -39,6 +41,11 @@ func New(kubeconfig, path, namespace string) *k8sreporter.KubernetesReporter {
 	crds := []k8sreporter.CRData{
 		{Cr: &v1beta1.MetalLBList{}},
 		{Cr: &corev1.ServiceList{}},
+	}
+
+	err := os.Mkdir(path, 0755)
+	if err != nil && !errors.Is(err, os.ErrExist) {
+		log.Fatalf("Failed to create the reporter dir: %s", err)
 	}
 
 	reporter, err := k8sreporter.New(kubeconfig, addToScheme, dumpNamespace, path, crds...)

--- a/test/e2e/validation/validation_test.go
+++ b/test/e2e/validation/validation_test.go
@@ -56,7 +56,8 @@ func TestValidation(t *testing.T) {
 
 	if *reportPath != "" {
 		kubeconfig := os.Getenv("KUBECONFIG")
-		r = k8sreporter.New(kubeconfig, *reportPath, OperatorNameSpace)
+		reportPath := path.Join(*reportPath, "metallb_failure_report.log")
+		r = k8sreporter.New(kubeconfig, reportPath, OperatorNameSpace)
 	}
 
 	RunSpecs(t, "Metallb Operator Validation Suite", reporterConfig)


### PR DESCRIPTION
This commit moves the reporter.Dump() call into the FailHandler. We do this because previously, having the reporter dump in the ReportAfterEach, we didn't get the desired logs because the test namesapce would be cleaned beforehand in the AfterEach/ AfterAll phase.

Also, made the reporter to create a directory named "metallb_failure_report.log" to house all the failed tests from all of the test suites.