### PR TITLE
WIP: CI: fix frr-k8s certificate flake

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -423,6 +423,8 @@ jobs:
         run: |
           export KUBECONFIG=${HOME}/.kube/config
           kubectl apply -f config/samples/metallb.yaml
+          sleep 20
+          kubectl wait -n metallb-system --for=condition=Ready pod -l "component in (speaker,controller,frr-k8s,frr-k8s-webhook-server)" --timeout=180s
 
       - name: frr-k8s E2E Webhooks tests
         run: |

--- a/pkg/helm/frrk8s.go
+++ b/pkg/helm/frrk8s.go
@@ -231,10 +231,12 @@ func (c *frrK8SChartConfig) frrk8sValues(crdConfig *metallbv1beta1.MetalLB) map[
 		}
 	}
 	frrk8sValueMap["logLevel"] = logLevelValue(crdConfig)
+	frrk8sValueMap["restartOnRotatorSecretRefresh"] = true
 
 	if c.isOpenShift {
 		// OpenShift is responsible of managing the cert secret
 		frrk8sValueMap["disableCertRotation"] = true
+		frrk8sValueMap["restartOnRotatorSecretRefresh"] = nil // the cert rotator isn't started anyways
 	}
 
 	return frrk8sValueMap


### PR DESCRIPTION
As noted in the frr-k8s PR, this flag fixes the `tls: failed to verify certificate`
flake we're seeing a lot in CI.

WIP: waiting for a newer frr-k8s version