### PR TITLE
Makefile: update the golden files when running make bump_metallb

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -282,6 +282,7 @@ bump_metallb: ## Bumps metallb commit ID and creates manifests. It also validate
 	hack/bump_metallb.sh
 	$(MAKE) bin
 	$(MAKE) bundle-release
+	go test ./pkg/helm/... --update
 
 check_generated: ## Checks if there are any different with the current checkout
 	@echo "Checking generated files"


### PR DESCRIPTION
Most often than not, meaningful metallb bumps bring helm charts modifications. Because of that, automated bumps generally fails because of the differences with golden files.

Here, we facilitate the life of who is trying to bump metallb (human or machine) and run go test update automatically.