### PR TITLE
FRRK8s: apply the same selector / tolerations we apply to the speaker

### DIFF
--- a/pkg/helm/frrk8s.go
+++ b/pkg/helm/frrk8s.go
@@ -153,6 +153,15 @@ func frrk8sValues(envConfig params.EnvConfig, crdConfig *metallbv1beta1.MetalLB)
 		frrk8sValueMap["restartOnRotatorSecretRefresh"] = nil // the cert rotator isn't started anyways
 	}
 
+	// Mirror the behaviour of the speaker pods as frrk8s pods must follow the
+	// speaker pods.
+	if crdConfig.Spec.SpeakerNodeSelector != nil {
+		frrk8sValueMap["nodeSelector"] = toInterfaceMap(crdConfig.Spec.SpeakerNodeSelector)
+	}
+	if crdConfig.Spec.SpeakerTolerations != nil {
+		frrk8sValueMap["tolerations"] = crdConfig.Spec.SpeakerTolerations
+	}
+
 	return frrk8sValueMap
 }
 


### PR DESCRIPTION
The frrk8s pods should follow the same scheduling as the speaker (as long as we deploy both together). Here we apply the same node selector / tolerations so they run on the same set of nodes.