### PR TITLE
Added all in one makefile rule to to deploy bundle images

### DIFF
--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -1,10 +1,10 @@
 resources:
-  - manager.yaml
+- manager.yaml
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 patchesStrategicMerge:
-  - env.yaml
+- env.yaml
 images:
-  - name: controller
-    newName: quay.io/metallb/metallb-operator
-    newTag: main
+- name: controller
+  newName: quay.io/metallb/metallb-operator
+  newTag: dev


### PR DESCRIPTION
Fixes #459 
I've added `deploy-olm-real` rule to the Makefile, making it easier to deploy the operator. Now, it handles tasks like building images, updating references, applying resources, and ensuring readiness, streamlining cluster management for smoother operation.