### PR TITLE
bump core github actions to latest release

### DIFF
--- a/.github/workflows/bump_metallb.yml
+++ b/.github/workflows/bump_metallb.yml
@@ -11,11 +11,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Latest Metal LB Operator
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: metallboperator
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: metallb/metallb
           path: metallb
@@ -45,7 +45,7 @@ jobs:
           else
             echo "has_changes=true" >> $GITHUB_OUTPUT
           fi
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Bump metallb

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -153,7 +153,7 @@ jobs:
         ref: v0.13 # previous release version
         fetch-depth: 0 # Fetch all history for all tags and branches
 
-    - uses: actions/setup-go@v2
+    - uses: actions/setup-go@v5
       with:
         go-version-file: "go.mod"
         cache: true
@@ -325,14 +325,14 @@ jobs:
           rm -f Chart.yaml
 
       - name: Checkout MetalLB
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           repository: metallb/metallb
           path: metallb
           ref: "${{ steps.metallb_ref.outputs.content }}"
 
       - name: Checkout frr-k8s
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           repository: metallb/frr-k8s
           path: frr-k8s

--- a/.github/workflows/composite/collectlogs/action.yaml
+++ b/.github/workflows/composite/collectlogs/action.yaml
@@ -10,7 +10,7 @@ runs:
   using: "composite"
   steps:
     - name: Archive E2E Tests logs
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: ${{ inputs.artifact-name }}-logs
         path: /tmp/kind_logs
@@ -26,7 +26,7 @@ runs:
           sudo chmod -R o+r /tmp/kind_logs
 
     - name: Archive kind logs
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name:  ${{ inputs.artifact-name }}-kind-logs
         path: /tmp/kind_logs

--- a/.github/workflows/composite/setup/action.yaml
+++ b/.github/workflows/composite/setup/action.yaml
@@ -10,7 +10,7 @@ runs:
         path: metallboperator
         fetch-depth: 0 # Fetch all history for all tags and branches 
 
-    - uses: actions/setup-go@v4
+    - uses: actions/setup-go@v5
       with:
         go-version-file: "go.mod"
         cache: true

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -18,11 +18,11 @@ jobs:
     name: Go ${{ matrix.go }}
     steps:
       - name: Checkout Metal LB Operator
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0 # Fetch all history for all tags and branches
 
-      - uses: actions/setup-go@v2
+      - uses: actions/setup-go@v5
         id: go
         with:
           go-version: ${{ matrix.go }}
@@ -52,7 +52,7 @@ jobs:
 
       - name: Archive E2E Tests logs
         if: ${{ failure() }}
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: test_e2e_logs
           path: /tmp/test_e2e_logs/
@@ -64,7 +64,7 @@ jobs:
 
       - name: Archive kind logs
         if: ${{ failure() }}
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: kind_logs
           path: /tmp/kind_logs
@@ -85,7 +85,7 @@ jobs:
           cosign-release: "v2.2.4"
 
       - name: Code checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup docker buildx
         uses: docker/setup-buildx-action@v2
@@ -138,7 +138,7 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/v') # we craft releases only for tags
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Build changelog

--- a/.github/workflows/verify_version.yaml
+++ b/.github/workflows/verify_version.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Verify Version Bump


### PR DESCRIPTION
**Is this a BUG FIX or a FEATURE ?**:

 /kind cleanup

**What this PR does / why we need it**:

This bumps standard `actions/*` GH actions to a standard/latest release

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
