### PR TITLE
E2E: add frr-k8s-external deployment entry

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -88,7 +88,7 @@ jobs:
       run: |
         export KUBECONFIG=${HOME}/.kube/config
         make test-validation
-        make test-e2e
+        SKIP="FRR-K8s-external" make test-e2e
 
     - name: Collect Logs
       if: ${{ failure() }}
@@ -125,7 +125,7 @@ jobs:
       run: |
         export KUBECONFIG=${HOME}/.kube/config
         make test-validation
-        make test-e2e
+        SKIP="FRR-K8s-external" make test-e2e
 
     - name: Collect Logs
       if: ${{ failure() }}
@@ -182,7 +182,7 @@ jobs:
       run: |
         export KUBECONFIG=${HOME}/.kube/config
         make  test-validation
-        make test-e2e
+        SKIP="FRR-K8s-external" make test-e2e
 
     - name: Collect Logs
       if: ${{ failure() }}
@@ -218,7 +218,7 @@ jobs:
         cd ${GITHUB_WORKSPACE}/metallboperator-latest
         export KUBECONFIG=${HOME}/.kube/config
         make test-validation
-        make test-e2e
+        SKIP="FRR-K8s-external" make test-e2e
 
     - name: Checkout
       uses: actions/checkout@v4
@@ -367,7 +367,7 @@ jobs:
         run: |
           export KUBECONFIG=${HOME}/.kube/config
           make test-validation
-          make test-e2e
+          SKIP="FRR-K8s-external" make test-e2e
           kubectl wait -n metallb-system --for=delete pod -l "component in (speaker,controller,frr-k8s,frr-k8s-webhook-server)" --timeout=180s
 
       - name: Deploy MetalLB resource

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -48,7 +48,7 @@ jobs:
         run: |
           export KUBECONFIG=${HOME}/.kube/config
           make test-validation
-          SKIP="frr-k8s" make test-e2e
+          SKIP="FRR-K8s-external" make test-e2e
 
       - name: Archive E2E Tests logs
         if: ${{ failure() }}


### PR DESCRIPTION
We add an entry for frr-k8s-external bgp mode,
which should be ran with the namespace where frr-k8s is already deployed. We skip it in CI until we put a
setup that deploys frr-k8s before running the tests.

<!-- Thanks for sending a pull request!
1. If this is your first time, please read the [contributing guide](https://metallb.universe.tf/community/#contributing)
2. For non-trivial pull requests, please [file an
   issue](https://github.com/metallb/metallb-operator/issues/new) first, and get
   agreement that the change is a good idea, and a general guideline
   for how it should be implemented, before sending code. Large PRs
   that weren't first discussed and agreed upon in an issue won't be
   accepted.
3. If the PR fixes a particular bug, please include the words "Fixed
   #<issue number>" in the PR text, so that the bug auto-closes when
   the PR is merged.
-->

**Is this a BUG FIX or a FEATURE ?**:

 /kind cleanup

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
