### PR TITLE
Make the min version CNO supports frr-k8s parametric

### DIFF
--- a/controllers/metallb_controller.go
+++ b/controllers/metallb_controller.go
@@ -174,7 +174,7 @@ func (r *MetalLBReconciler) syncMetalLBResources(ctx context.Context, config *me
 
 	bgpType := params.BGPType(config, r.EnvConfig)
 	if r.EnvConfig.MustDeployFRRK8sFromCNO && r.EnvConfig.IsOpenshift && (bgpType == metallbv1beta1.FRRK8sExternalMode) {
-		supportsFRRK8s, err := openshift.SupportsFRRK8s(ctx, r.Client)
+		supportsFRRK8s, err := openshift.SupportsFRRK8s(ctx, r.Client, r.EnvConfig)
 		if err != nil {
 			return err
 		}

--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,7 @@ require (
 
 require (
 	github.com/AdaLogics/go-fuzz-headers v0.0.0-20230811130428-ced1acdcaa24 // indirect
+	github.com/Masterminds/semver v1.5.0 // indirect
 	github.com/Microsoft/hcsshim v0.11.4 // indirect
 	github.com/containerd/log v0.1.0 // indirect
 	github.com/evanphx/json-patch/v5 v5.9.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -609,6 +609,8 @@ github.com/MakeNowJust/heredoc v1.0.0 h1:cXCdzVdstXyiTqTvfqk9SDHpKNjxuom+DOlyEeQ
 github.com/MakeNowJust/heredoc v1.0.0/go.mod h1:mG5amYoWBHf8vpLOuehzbGGw0EHxpZZ6lCpQ4fNJ8LE=
 github.com/Masterminds/goutils v1.1.1 h1:5nUrii3FMTL5diU80unEVvNevw1nH4+ZV4DSLVJLSYI=
 github.com/Masterminds/goutils v1.1.1/go.mod h1:8cTjp+g8YejhMuvIA5y2vz3BpJxksy863GQaJW2MFNU=
+github.com/Masterminds/semver v1.5.0 h1:H65muMkzWKEuNDnfl9d70GUjFniHKHRbFPGBuZ3QEww=
+github.com/Masterminds/semver v1.5.0/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
 github.com/Masterminds/semver/v3 v3.2.0/go.mod h1:qvl/7zhW3nngYb5+80sSMF+FG2BjYrf8m9wsX0PNOMQ=
 github.com/Masterminds/semver/v3 v3.2.1 h1:RN9w6+7QoMeJVGyfmbcgs28Br8cvmnucEXnY0rYXWg0=
 github.com/Masterminds/semver/v3 v3.2.1/go.mod h1:qvl/7zhW3nngYb5+80sSMF+FG2BjYrf8m9wsX0PNOMQ=

--- a/pkg/openshift/openshift_test.go
+++ b/pkg/openshift/openshift_test.go
@@ -3,6 +3,7 @@ package openshift
 import (
 	"testing"
 
+	"github.com/metallb/metallb-operator/pkg/params"
 	openshiftconfigv1 "github.com/openshift/api/config/v1"
 )
 
@@ -103,7 +104,8 @@ func TestCnoSupportsFRRK8s(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			supports, err := cnoSupportsFRRK8s(test.cno)
+			envConfig := params.EnvConfig{CNOMinFRRK8sVersion: "4.17.0-0"}
+			supports, err := cnoSupportsFRRK8s(test.cno, envConfig)
 			if test.shouldErr && err == nil {
 				t.Fatalf("expected error, got nil")
 			}


### PR DESCRIPTION


<!-- Thanks for sending a pull request!
1. If this is your first time, please read the [contributing guide](https://metallb.universe.tf/community/#contributing)
2. For non-trivial pull requests, please [file an
   issue](https://github.com/metallb/metallb-operator/issues/new) first, and get
   agreement that the change is a good idea, and a general guideline
   for how it should be implemented, before sending code. Large PRs
   that weren't first discussed and agreed upon in an issue won't be
   accepted.
3. If the PR fixes a particular bug, please include the words "Fixed
   #<issue number>" in the PR text, so that the bug auto-closes when
   the PR is merged.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
> /kind bug
> /kind cleanup
/kind feature
> /kind design
> /kind flake
> /kind failing
> /kind documentation
> /kind regression

**What this PR does / why we need it**:

Openshift only behavior: at some point the operator will have to signal Openshift's Cluster Network Operator to install frr-k8s. This is to make the minimum version supporting it parametric.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
