### PR TITLE
Enable frr-k8s-external for OpenShift deployments

### DIFF
--- a/controllers/metallb_controller.go
+++ b/controllers/metallb_controller.go
@@ -245,6 +245,9 @@ func (r *MetalLBReconciler) syncMetalLBResources(ctx context.Context, config *me
 }
 
 func validateBGPMode(config *metallbv1beta1.MetalLB, isOpenshift bool) error {
+	if config.Spec.BGPBackend == metallbv1beta1.FRRK8sExternalMode && isOpenshift {
+		return nil
+	}
 	if config.Spec.BGPBackend != "" &&
 		config.Spec.BGPBackend != metallbv1beta1.NativeMode &&
 		config.Spec.BGPBackend != metallbv1beta1.FRRK8sMode &&

--- a/test/e2e/functional/tests/e2e.go
+++ b/test/e2e/functional/tests/e2e.go
@@ -166,7 +166,11 @@ var _ = Describe("metallb", func() {
 			}, metallbutils.DeployTimeout, metallbutils.Interval).ShouldNot(HaveOccurred())
 
 			By("checking the controller is running in the right bgp mode")
-			checkControllerBGPMode(bgpType)
+			expectedMode := bgpType
+			if bgpType == metallbv1beta1.FRRK8sExternalMode {
+				expectedMode = metallbv1beta1.FRRK8sMode
+			}
+			checkControllerBGPMode(expectedMode)
 
 			By("checking MetalLB controller deployment is in running state")
 			Eventually(func() error {
@@ -195,7 +199,7 @@ var _ = Describe("metallb", func() {
 			}, metallbutils.DeployTimeout, metallbutils.Interval).ShouldNot(HaveOccurred())
 
 			By("checking the speaker is running in the right bgp mode")
-			checkSpeakerBGPMode(bgpType)
+			checkSpeakerBGPMode(expectedMode)
 
 			By("checking MetalLB daemonset is in running state")
 			Eventually(func() error {
@@ -254,7 +258,7 @@ var _ = Describe("metallb", func() {
 				return true
 			}, 5*time.Minute, 5*time.Second).Should(BeTrue())
 
-			if bgpType != metallbv1beta1.FRRK8sMode {
+			if bgpType != metallbv1beta1.FRRK8sMode && bgpType != metallbv1beta1.FRRK8sExternalMode {
 				return
 			}
 			By("checking frr-k8s daemonset is in running state")


### PR DESCRIPTION
The current code blocked it from being enabled explicitly, here we allow it for OpenShift deployments.
In addition, fixed the E2E for the external mode.

**Is this a BUG FIX or a FEATURE ?**:

/kind cleanup

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
