### PR TITLE
Add network policies for the operator

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -290,7 +290,7 @@ jobs:
         run: |
           cd ${GITHUB_WORKSPACE}/metallb
           inv remove-lb-exclusion-from-nodes
-          sudo -E env "PATH=$PATH" inv e2etest -b frr --skip "IPV6|DUALSTACK|FRRK8S-MODE|L2ServiceStatus|Networkpolicies" -e /tmp/kind_logs
+          sudo -E env "PATH=$PATH" inv e2etest -b frr --skip "IPV6|DUALSTACK|FRRK8S-MODE|L2ServiceStatus" -e /tmp/kind_logs
 
       - name: Collect Logs
         if: ${{ failure() }}
@@ -395,7 +395,7 @@ jobs:
         run: |
           cd ${GITHUB_WORKSPACE}/metallb
           inv remove-lb-exclusion-from-nodes
-          sudo -E env "PATH=$PATH" inv e2etest -b frr-k8s --skip "IPV6|DUALSTACK|FRR-MODE|L2ServiceStatus|Networkpolicies" -e /tmp/kind_logs
+          sudo -E env "PATH=$PATH" inv e2etest -b frr-k8s --skip "IPV6|DUALSTACK|FRR-MODE|L2ServiceStatus" -e /tmp/kind_logs
 
       - name: Collect Logs
         if: ${{ failure() }}

--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ OPM=$(shell pwd)/_cache/opm
 KUSTOMIZE_VERSION ?= v5.5.0
 KUSTOMIZE=$(shell pwd)/_cache/kustomize
 KIND ?= $(shell pwd)/_cache/kind
-KIND_VERSION=v0.23.0
+KIND_VERSION ?= v0.29.0
 CACHE_PATH=$(shell pwd)/_cache
 
 

--- a/Makefile
+++ b/Makefile
@@ -46,9 +46,9 @@ else
 GOBIN=$(shell go env GOBIN)
 endif
 
-OPERATOR_SDK_VERSION ?= v1.38.0
-OLM_VERSION ?= v0.18.3
-OPM_VERSION ?= v1.23.2
+OPERATOR_SDK_VERSION ?= v1.40.0
+OLM_VERSION ?= v0.32.0
+OPM_VERSION ?= v1.55.0
 KUSTOMIZE_VERSION ?= v5.5.0
 KUSTOMIZE=$(shell pwd)/_cache/kustomize
 KIND ?= $(shell pwd)/_cache/kind
@@ -198,7 +198,7 @@ deploy-prometheus:
 # download controller-gen if necessary
 controller-gen:
 ifeq (, $(shell which controller-gen))
-	go install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.14.0
+	go install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.18.0
 CONTROLLER_GEN=$(GOBIN)/controller-gen
 else
 CONTROLLER_GEN=$(shell which controller-gen)

--- a/Makefile
+++ b/Makefile
@@ -54,6 +54,8 @@ KUSTOMIZE_VERSION ?= v5.5.0
 KUSTOMIZE=$(shell pwd)/_cache/kustomize
 KIND ?= $(shell pwd)/_cache/kind
 KIND_VERSION ?= v0.29.0
+CONTROLLER_GEN=$(shell pwd)/_cache/controller-gen
+CONTROLLER_GEN_VERSION ?= v0.18.0
 CACHE_PATH=$(shell pwd)/_cache
 
 
@@ -196,11 +198,9 @@ deploy-prometheus:
 # find or download controller-gen
 # download controller-gen if necessary
 controller-gen:
-ifeq (, $(shell which controller-gen))
-	go install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.18.0
-CONTROLLER_GEN=$(GOBIN)/controller-gen
-else
-CONTROLLER_GEN=$(shell which controller-gen)
+	mkdir -p _cache
+ifeq (,$(findstring $(CONTROLLER_GEN_VERSION),$(shell _cache/controller-gen --version)))
+	GOBIN=$(CACHE_PATH) go install sigs.k8s.io/controller-tools/cmd/controller-gen@$(CONTROLLER_GEN_VERSION)
 endif
 
 # Get the current operator-sdk binary into the _cache dir.

--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,7 @@ endif
 OPERATOR_SDK_VERSION ?= v1.40.0
 OLM_VERSION ?= v0.32.0
 OPM_VERSION ?= v1.55.0
+OPM=$(shell pwd)/_cache/opm
 KUSTOMIZE_VERSION ?= v5.5.0
 KUSTOMIZE=$(shell pwd)/_cache/kustomize
 KIND ?= $(shell pwd)/_cache/kind
@@ -56,8 +57,6 @@ KIND_VERSION=v0.23.0
 CACHE_PATH=$(shell pwd)/_cache
 
 
-
-OPM_TOOL_URL=https://api.github.com/repos/operator-framework/operator-registry/releases
 
 TESTS_REPORTS_PATH ?= /tmp/test_e2e_logs/
 VALIDATION_TESTS_REPORTS_PATH ?= /tmp/test_validation_logs/
@@ -226,18 +225,15 @@ ifeq (,$(findstring $(OPERATOR_SDK_VERSION),$(shell _cache/operator-sdk version)
 	}
 endif
 
-# Get the current opm binary. If there isn't any, we'll use the
-# GOBIN path
+# Get the current opm binary.
 opm:
-ifeq (, $(shell which opm))
+	mkdir -p _cache
+ifeq (,$(findstring $(OPM_VERSION),$(shell _cache/opm)))
 	@{ \
 	set -e ;\
-	curl -Lk https://github.com/operator-framework/operator-registry/releases/download/$(OPM_VERSION)/linux-amd64-opm > $(GOBIN)/opm ;\
-	chmod u+x $(GOBIN)/opm ;\
+	curl -Lk https://github.com/operator-framework/operator-registry/releases/download/$(OPM_VERSION)/linux-amd64-opm > _cache/opm ;\
+	chmod u+x _cache/opm ;\
 	}
-OPM=$(GOBIN)/opm
-else
-OPM=$(shell which opm)
 endif
 
 # Get the current kubectl binary. If there isn't any, we'll use the

--- a/bin/metallb-operator.yaml
+++ b/bin/metallb-operator.yaml
@@ -4412,6 +4412,12 @@ rules:
   - update
   - watch
 - apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - '*'
+- apiGroups:
   - operator.openshift.io
   resources:
   - networks
@@ -4650,6 +4656,59 @@ spec:
         secret:
           defaultMode: 420
           secretName: metallb-webhook-cert
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny
+  namespace: metallb-system
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  - Egress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: operator
+  namespace: metallb-system
+spec:
+  egress:
+  - ports:
+    - port: 6443
+      protocol: TCP
+  ingress:
+  - ports:
+    - port: 9443
+      protocol: TCP
+  podSelector:
+    matchLabels:
+      control-plane: controller-manager
+  policyTypes:
+  - Egress
+  - Ingress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: webhook-service
+  namespace: metallb-system
+spec:
+  egress:
+  - ports:
+    - port: 6443
+      protocol: TCP
+  ingress:
+  - ports:
+    - port: 9443
+      protocol: TCP
+  podSelector:
+    matchLabels:
+      component: webhook-server
+  policyTypes:
+  - Egress
+  - Ingress
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration

--- a/bin/metallb-operator.yaml
+++ b/bin/metallb-operator.yaml
@@ -1841,7 +1841,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.18.0
   name: metallbs.metallb.io
 spec:
   group: metallb.io
@@ -2829,10 +2829,8 @@ spec:
                           Claims lists the names of resources, defined in spec.resourceClaims,
                           that are used by this container.
 
-
                           This is an alpha field and requires enabling the
                           DynamicResourceAllocation feature gate.
-
 
                           This field is immutable. It can only be set for containers.
                         items:
@@ -3917,10 +3915,8 @@ spec:
                           Claims lists the names of resources, defined in spec.resourceClaims,
                           that are used by this container.
 
-
                           This is an alpha field and requires enabling the
                           DynamicResourceAllocation feature gate.
-
 
                           This field is immutable. It can only be set for containers.
                         items:
@@ -4016,16 +4012,8 @@ spec:
               conditions:
                 description: Conditions show the current state of the MetalLB Operator
                 items:
-                  description: "Condition contains details for one aspect of the current
-                    state of this API Resource.\n---\nThis struct is intended for
-                    direct use as an array at the field path .status.conditions.  For
-                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
-                    observations of a foo's current state.\n\t    // Known .status.conditions.type
-                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
-                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
-                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
-                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
-                    \   // other fields\n\t}"
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
                   properties:
                     lastTransitionTime:
                       description: |-
@@ -4066,12 +4054,7 @@ spec:
                       - Unknown
                       type: string
                     type:
-                      description: |-
-                        type of condition in CamelCase or in foo.example.com/CamelCase.
-                        ---
-                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
-                        useful (see .node.status.conditions), the ability to deconflict is important.
-                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
                       maxLength: 316
                       pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                       type: string
@@ -4419,17 +4402,6 @@ rules:
   - monitoring.coreos.com
   resources:
   - podmonitors
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - monitoring.coreos.com
-  resources:
   - servicemonitors
   verbs:
   - create

--- a/bindata/deployment/helm/metallb/templates/networkpolicy.yaml
+++ b/bindata/deployment/helm/metallb/templates/networkpolicy.yaml
@@ -22,7 +22,7 @@ spec:
   podSelector:
     matchLabels:
       {{- include "metallb.selectorLabels" . | nindent 6 }}
-      app.kubernetes.io/component: controller
+      component: controller
   egress:
     - ports:
         - protocol: TCP

--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -6,7 +6,7 @@ LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
 LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
 LABEL operators.operatorframework.io.bundle.package.v1=metallb-operator
 LABEL operators.operatorframework.io.bundle.channels.v1=alpha
-LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.38.0
+LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.40.0
 LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
 LABEL operators.operatorframework.io.metrics.project_layout=go.kubebuilder.io/v4
 

--- a/bundle/manifests/default-deny_networking.k8s.io_v1_networkpolicy.yaml
+++ b/bundle/manifests/default-deny_networking.k8s.io_v1_networkpolicy.yaml
@@ -1,0 +1,9 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  - Egress

--- a/bundle/manifests/metallb-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/metallb-operator.clusterserviceversion.yaml
@@ -432,7 +432,7 @@ metadata:
     categories: Networking
     certified: "false"
     containerImage: quay.io/metallb/metallb-operator
-    createdAt: "2025-07-07T09:19:59Z"
+    createdAt: "2025-07-07T09:21:14Z"
     description: An operator for deploying MetalLB on a kubernetes cluster.
     operators.operatorframework.io/builder: operator-sdk-v1.40.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4

--- a/bundle/manifests/metallb-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/metallb-operator.clusterserviceversion.yaml
@@ -432,9 +432,9 @@ metadata:
     categories: Networking
     certified: "false"
     containerImage: quay.io/metallb/metallb-operator
-    createdAt: "2025-07-02T05:08:22Z"
+    createdAt: "2025-07-07T09:19:59Z"
     description: An operator for deploying MetalLB on a kubernetes cluster.
-    operators.operatorframework.io/builder: operator-sdk-v1.38.0
+    operators.operatorframework.io/builder: operator-sdk-v1.40.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
     repository: https://github.com/metallb/metallb-operator
     support: Community
@@ -781,17 +781,6 @@ spec:
                 - monitoring.coreos.com
               resources:
                 - podmonitors
-              verbs:
-                - create
-                - delete
-                - get
-                - list
-                - patch
-                - update
-                - watch
-            - apiGroups:
-                - monitoring.coreos.com
-              resources:
                 - servicemonitors
               verbs:
                 - create

--- a/bundle/manifests/metallb-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/metallb-operator.clusterserviceversion.yaml
@@ -432,7 +432,7 @@ metadata:
     categories: Networking
     certified: "false"
     containerImage: quay.io/metallb/metallb-operator
-    createdAt: "2025-07-07T09:23:28Z"
+    createdAt: "2025-07-07T09:53:39Z"
     description: An operator for deploying MetalLB on a kubernetes cluster.
     operators.operatorframework.io/builder: operator-sdk-v1.40.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
@@ -790,6 +790,12 @@ spec:
                 - patch
                 - update
                 - watch
+            - apiGroups:
+                - networking.k8s.io
+              resources:
+                - networkpolicies
+              verbs:
+                - '*'
             - apiGroups:
                 - operator.openshift.io
               resources:

--- a/bundle/manifests/metallb-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/metallb-operator.clusterserviceversion.yaml
@@ -432,7 +432,7 @@ metadata:
     categories: Networking
     certified: "false"
     containerImage: quay.io/metallb/metallb-operator
-    createdAt: "2025-07-07T09:21:14Z"
+    createdAt: "2025-07-07T09:22:18Z"
     description: An operator for deploying MetalLB on a kubernetes cluster.
     operators.operatorframework.io/builder: operator-sdk-v1.40.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4

--- a/bundle/manifests/metallb-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/metallb-operator.clusterserviceversion.yaml
@@ -432,7 +432,7 @@ metadata:
     categories: Networking
     certified: "false"
     containerImage: quay.io/metallb/metallb-operator
-    createdAt: "2025-07-07T09:22:18Z"
+    createdAt: "2025-07-07T09:23:28Z"
     description: An operator for deploying MetalLB on a kubernetes cluster.
     operators.operatorframework.io/builder: operator-sdk-v1.40.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4

--- a/bundle/manifests/metallb.io_metallbs.yaml
+++ b/bundle/manifests/metallb.io_metallbs.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.18.0
   creationTimestamp: null
   name: metallbs.metallb.io
 spec:
@@ -991,10 +991,8 @@ spec:
                           Claims lists the names of resources, defined in spec.resourceClaims,
                           that are used by this container.
 
-
                           This is an alpha field and requires enabling the
                           DynamicResourceAllocation feature gate.
-
 
                           This field is immutable. It can only be set for containers.
                         items:
@@ -2079,10 +2077,8 @@ spec:
                           Claims lists the names of resources, defined in spec.resourceClaims,
                           that are used by this container.
 
-
                           This is an alpha field and requires enabling the
                           DynamicResourceAllocation feature gate.
-
 
                           This field is immutable. It can only be set for containers.
                         items:
@@ -2178,16 +2174,8 @@ spec:
               conditions:
                 description: Conditions show the current state of the MetalLB Operator
                 items:
-                  description: "Condition contains details for one aspect of the current
-                    state of this API Resource.\n---\nThis struct is intended for
-                    direct use as an array at the field path .status.conditions.  For
-                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
-                    observations of a foo's current state.\n\t    // Known .status.conditions.type
-                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
-                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
-                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
-                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
-                    \   // other fields\n\t}"
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
                   properties:
                     lastTransitionTime:
                       description: |-
@@ -2228,12 +2216,7 @@ spec:
                       - Unknown
                       type: string
                     type:
-                      description: |-
-                        type of condition in CamelCase or in foo.example.com/CamelCase.
-                        ---
-                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
-                        useful (see .node.status.conditions), the ability to deconflict is important.
-                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
                       maxLength: 316
                       pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                       type: string

--- a/bundle/manifests/operator_networking.k8s.io_v1_networkpolicy.yaml
+++ b/bundle/manifests/operator_networking.k8s.io_v1_networkpolicy.yaml
@@ -1,0 +1,19 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: operator
+spec:
+  egress:
+  - ports:
+    - port: 6443
+      protocol: TCP
+  ingress:
+  - ports:
+    - port: 9443
+      protocol: TCP
+  podSelector:
+    matchLabels:
+      control-plane: controller-manager
+  policyTypes:
+  - Egress
+  - Ingress

--- a/bundle/manifests/webhook-service_networking.k8s.io_v1_networkpolicy.yaml
+++ b/bundle/manifests/webhook-service_networking.k8s.io_v1_networkpolicy.yaml
@@ -1,0 +1,19 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: webhook-service
+spec:
+  egress:
+  - ports:
+    - port: 6443
+      protocol: TCP
+  ingress:
+  - ports:
+    - port: 9443
+      protocol: TCP
+  podSelector:
+    matchLabels:
+      component: webhook-server
+  policyTypes:
+  - Egress
+  - Ingress

--- a/bundle/metadata/annotations.yaml
+++ b/bundle/metadata/annotations.yaml
@@ -5,7 +5,7 @@ annotations:
   operators.operatorframework.io.bundle.metadata.v1: metadata/
   operators.operatorframework.io.bundle.package.v1: metallb-operator
   operators.operatorframework.io.bundle.channels.v1: alpha
-  operators.operatorframework.io.metrics.builder: operator-sdk-v1.38.0
+  operators.operatorframework.io.metrics.builder: operator-sdk-v1.40.0
   operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
   operators.operatorframework.io.metrics.project_layout: go.kubebuilder.io/v4
 

--- a/config/crd/bases/metallb.io_metallbs.yaml
+++ b/config/crd/bases/metallb.io_metallbs.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.18.0
   name: metallbs.metallb.io
 spec:
   group: metallb.io
@@ -991,10 +991,8 @@ spec:
                           Claims lists the names of resources, defined in spec.resourceClaims,
                           that are used by this container.
 
-
                           This is an alpha field and requires enabling the
                           DynamicResourceAllocation feature gate.
-
 
                           This field is immutable. It can only be set for containers.
                         items:
@@ -2079,10 +2077,8 @@ spec:
                           Claims lists the names of resources, defined in spec.resourceClaims,
                           that are used by this container.
 
-
                           This is an alpha field and requires enabling the
                           DynamicResourceAllocation feature gate.
-
 
                           This field is immutable. It can only be set for containers.
                         items:
@@ -2178,16 +2174,8 @@ spec:
               conditions:
                 description: Conditions show the current state of the MetalLB Operator
                 items:
-                  description: "Condition contains details for one aspect of the current
-                    state of this API Resource.\n---\nThis struct is intended for
-                    direct use as an array at the field path .status.conditions.  For
-                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
-                    observations of a foo's current state.\n\t    // Known .status.conditions.type
-                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
-                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
-                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
-                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
-                    \   // other fields\n\t}"
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
                   properties:
                     lastTransitionTime:
                       description: |-
@@ -2228,12 +2216,7 @@ spec:
                       - Unknown
                       type: string
                     type:
-                      description: |-
-                        type of condition in CamelCase or in foo.example.com/CamelCase.
-                        ---
-                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
-                        useful (see .node.status.conditions), the ability to deconflict is important.
-                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
                       maxLength: 316
                       pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                       type: string

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -10,6 +10,7 @@ resources:
 - ../rbac
 - ../manager
 - ../webhook
+- ../networkpolicies
 
 transformers:
 - ./kustomizeconfig/add-prefix.yaml

--- a/config/networkpolicies/deny_all.yaml
+++ b/config/networkpolicies/deny_all.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny
+  namespace: metallb-system
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  - Egress

--- a/config/networkpolicies/kustomization.yaml
+++ b/config/networkpolicies/kustomization.yaml
@@ -1,0 +1,4 @@
+resources:
+- deny_all.yaml
+- operator.yaml
+- webhook.yaml

--- a/config/networkpolicies/operator.yaml
+++ b/config/networkpolicies/operator.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+ name: operator
+ namespace: metallb-system
+spec:
+  podSelector:
+    matchLabels:
+      control-plane: controller-manager
+  egress:
+     - ports: # to-api
+         - protocol: TCP
+           port: 6443
+  ingress:
+    - ports: # webhook for metallb.metallb.io
+        - protocol: TCP
+          port: 9443
+  policyTypes:
+    - Egress
+    - Ingress

--- a/config/networkpolicies/webhook.yaml
+++ b/config/networkpolicies/webhook.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: webhook-service
+  namespace: metallb-system
+spec:
+  podSelector:
+    matchLabels:
+      component: webhook-server
+  egress:
+    - ports:
+       - protocol: TCP
+         port: 6443
+  ingress:
+    - ports:
+        - protocol: TCP
+          port: 9443
+  policyTypes:
+    - Egress
+    - Ingress

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -95,6 +95,12 @@ rules:
   - update
   - watch
 - apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - '*'
+- apiGroups:
   - operator.openshift.io
   resources:
   - networks

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -85,17 +85,6 @@ rules:
   - monitoring.coreos.com
   resources:
   - podmonitors
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - monitoring.coreos.com
-  resources:
   - servicemonitors
   verbs:
   - create

--- a/hack/generate-metallb-manifests.sh
+++ b/hack/generate-metallb-manifests.sh
@@ -50,6 +50,7 @@ rm -f "$METALLB_PATH"/charts/metallb/templates/webhooks.yaml
 yq e --inplace 'del(."dependencies")' "$METALLB_PATH"/charts/metallb/Chart.yaml
 
 find "$METALLB_PATH"/charts/metallb -type f -exec sed -i -e 's/{{ template "metallb.fullname" . }}-//g' {} \;
+sed -i -e 's/app.kubernetes.io\///g' "$METALLB_PATH"/charts/metallb/templates/networkpolicy.yaml
 sed -i -e 's/app.kubernetes.io\///g' "$METALLB_PATH"/charts/metallb/templates/controller.yaml
 sed -i -e 's/metallb-webhook-service/webhook-service/g' "$METALLB_PATH"/charts/metallb/templates/controller.yaml
 sed -i -e 's/app.kubernetes.io\/component/component/g' "$METALLB_PATH"/charts/metallb/templates/speaker.yaml

--- a/hack/kind/kind.sh
+++ b/hack/kind/kind.sh
@@ -49,7 +49,7 @@ fi
 # Create a second network interface, useful for metallb's e2e tests
 docker network create --ipv6 --subnet fc00:f853:ccd:e791::/64 -d bridge network2
 
-KIND_NODES=$(kind get nodes --name "${KIND_CLUSTER_NAME}")
+KIND_NODES=$("${KIND_BIN}" get nodes --name "${KIND_CLUSTER_NAME}")
 for n in $KIND_NODES; do
   docker network connect network2 "$n"
 done

--- a/main.go
+++ b/main.go
@@ -59,6 +59,8 @@ const (
 	caOrganization = "metallb"
 )
 
+// +kubebuilder:rbac:groups=networking.k8s.io,resources=networkpolicies,verbs="*"
+
 var (
 	scheme            = runtime.NewScheme()
 	setupLog          = ctrl.Log.WithName("setup")

--- a/pkg/helm/metallb.go
+++ b/pkg/helm/metallb.go
@@ -186,6 +186,7 @@ func patchMetalLBChartValues(envConfig params.EnvConfig, crdConfig *metallbv1bet
 	valuesMap["controller"] = controllerValues(envConfig, crdConfig)
 	valuesMap["speaker"] = speakerValues(envConfig, crdConfig)
 	valuesMap["frrk8s"] = metalLBFrrk8sValues(envConfig, crdConfig)
+	valuesMap["networkpolicies"] = netpolValues(envConfig)
 }
 
 func loadBalancerClassValue(crdConfig *metallbv1beta1.MetalLB) string {
@@ -330,6 +331,13 @@ func speakerValues(envConfig params.EnvConfig, crdConfig *metallbv1beta1.MetalLB
 		}
 	}
 	return speakerValueMap
+}
+
+func netpolValues(envConfig params.EnvConfig) map[string]any {
+	ret := map[string]any{
+		"enabled": !envConfig.DisableNetworkPolicies,
+	}
+	return ret
 }
 
 func metalLBFrrk8sValues(envConfig params.EnvConfig, crdConfig *metallbv1beta1.MetalLB) map[string]interface{} {

--- a/pkg/params/params.go
+++ b/pkg/params/params.go
@@ -49,6 +49,7 @@ type EnvConfig struct {
 	SecureMetricsPort          int
 	DeployPodMonitors          bool
 	DeployServiceMonitors      bool
+	DisableNetworkPolicies     bool
 	IsOpenshift                bool
 	MustDeployFRRK8sFromCNO    bool
 }
@@ -126,6 +127,9 @@ func FromEnvironment(isOpenshift bool) (EnvConfig, error) {
 	}
 	if os.Getenv("DEPLOY_SERVICEMONITORS") == "true" {
 		res.DeployServiceMonitors = true
+	}
+	if os.Getenv("DISABLE_NETWORK_POLICIES") == "true" {
+		res.DisableNetworkPolicies = true
 	}
 
 	res.FRRK8sExternalNamespace = os.Getenv("FRRK8S_EXTERNAL_NAMESPACE")

--- a/pkg/params/params_test.go
+++ b/pkg/params/params_test.go
@@ -101,6 +101,44 @@ func TestFromEnvironment(t *testing.T) {
 				DeployServiceMonitors:      true,
 			},
 		},
+		{
+			desc: "with network policies enabled",
+			setup: func() {
+				setBasics()
+				os.Setenv("DISABLE_NETWORK_POLICIES", "true")
+			},
+			expected: EnvConfig{
+				Namespace: "test-namespace",
+				ControllerImage: ImageInfo{
+					Repo: "test-controller-image",
+					Tag:  "1",
+				},
+				SpeakerImage: ImageInfo{
+					Repo: "test-speaker-image",
+					Tag:  "2",
+				},
+				FRRImage: ImageInfo{
+					Repo: "test-frr-image",
+					Tag:  "3",
+				},
+				KubeRBacImage: ImageInfo{
+					Repo: "test-kube-rbac-proxy-image",
+					Tag:  "4",
+				},
+				FRRK8sImage: ImageInfo{
+					Repo: "test-frrk8s-image",
+					Tag:  "5",
+				},
+				MLBindPort:                 7946,
+				MetricsPort:                7472,
+				FRRMetricsPort:             7473,
+				FRRK8sMetricsPort:          7572,
+				FRRK8sFRRMetricsPort:       7573,
+				SecureFRRK8sMetricsPort:    9140,
+				SecureFRRK8sFRRMetricsPort: 9141,
+				DisableNetworkPolicies:     true,
+			},
+		},
 	}
 
 	for _, test := range tests {
@@ -118,10 +156,8 @@ func TestFromEnvironment(t *testing.T) {
 			if res != test.expected {
 				t.Errorf("res different from expected, %s", cmp.Diff(res, test.expected))
 			}
-
 		})
 	}
-
 }
 
 func unset() {
@@ -138,8 +174,10 @@ func unset() {
 	os.Unsetenv("FRRK8S_FRR_METRICS_PORT")
 	os.Unsetenv("FRRK8S_HTTPS_METRICS_PORT")
 	os.Unsetenv("FRRK8S_FRR_HTTPS_METRICS_PORT")
+	os.Unsetenv("FRRK8S_METRICS_PORT")
 	os.Unsetenv("DEPLOY_PODMONITORS")
 	os.Unsetenv("DEPLOY_SERVICEMONITORS")
+	os.Unsetenv("DISABLE_NETWORK_POLICIES")
 	os.Unsetenv("KUBE_RBAC_PROXY_IMAGE")
 }
 


### PR DESCRIPTION
to the version which supports network policies

/kind feature
> /kind design
> /kind flake
> /kind failing
> /kind documentation
> /kind regression

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
Add operator network policies: included by default in deployment manifests and bundle, can be disabled by the use at manifest/bundle level during deployment.
Add operand network policies:  enabled when namespace contains any network policy, user can explicit control via DEPLOY_NETWORK_POLICIES environment variable.
```
