### PR TITLE
CI: update publish pipeline to latest versions

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -11,10 +11,10 @@ on:
       - "v[0-9]+.[0-9]+"
 jobs:
   main:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: ["1.21"]
+        go: ["1.24"]
     name: Go ${{ matrix.go }}
     steps:
       - name: Checkout Metal LB Operator
@@ -71,27 +71,25 @@ jobs:
 
   publish-image:
     needs: [main]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       id-token: write # needed for signing the images with GitHub OIDC Token
     steps:
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
 
       - name: Install Cosign
-        uses: sigstore/cosign-installer@main
-        with:
-          cosign-release: "v2.2.4"
+        uses: sigstore/cosign-installer@v3
 
       - name: Code checkout
         uses: actions/checkout@v4
 
       - name: Setup docker buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
       - name: Log into Quay
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: quay.io
           username: ${{ secrets.QUAY_USER }}
@@ -99,7 +97,7 @@ jobs:
 
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v5
         with:
           images: |
             quay.io/metallb/metallb-operator
@@ -112,7 +110,7 @@ jobs:
             org.opencontainers.image.description=operator for metallb, a network load-balancer implementation for Kubernetes using standard routing protocols
 
       - name: Build and push metallboperator
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v6
         id: build-and-push
         with:
           context: .
@@ -148,12 +146,12 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Create release
         id: create_release
-        uses: actions/create-release@latest
+        uses: softprops/action-gh-release@v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
         with:
-          tag_name: ${{ github.ref }}
-          release_name: Release ${{ github.ref }}
+          tag_name: ${{ github.ref_name }}
+          name: Release ${{ github.ref_name }}
           body: ${{steps.build_changelog.outputs.changelog}}
           draft: false
           prerelease: false


### PR DESCRIPTION
Updated all GitHub Actions to their latest stable versions:
- actions/checkout@v4 (https://github.com/actions/checkout/releases)
- actions/setup-go@v5 (https://github.com/actions/setup-go/releases)
- actions/upload-artifact@v4 (https://github.com/actions/upload-artifact/releases)
- docker/setup-qemu-action@v3 (https://github.com/docker/setup-qemu-action/releases)
- docker/setup-buildx-action@v3 (https://github.com/docker/setup-buildx-action/releases)
- docker/login-action@v3 (https://github.com/docker/login-action/releases)
- docker/metadata-action@v5 (https://github.com/docker/metadata-action/releases)
- docker/build-push-action@v6 (https://github.com/docker/build-push-action/releases)
- sigstore/cosign-installer@v3 (https://github.com/sigstore/cosign-installer/releases)
- softprops/action-gh-release@v2 (https://github.com/softprops/action-gh-release/releases)

Replaced deprecated actions/create-release with softprops/action-gh-release because actions/create-release is archived and no longer maintained by GitHub.

Removed hardcoded cosign version to use latest stable automatically instead of pinning to a specific version for better security updates.

Updated runner from ubuntu-20.04 to ubuntu-latest and Go from 1.21 to 1.24.

 /kind cleanup
> /kind feature
> /kind design
> /kind flake
> /kind failing
> /kind documentation
> /kind regression

**What this PR does / why we need it**:

The push  quay.io/metallb/metallb-operator:main does not take place, https://github.com/metallb/metallb-operator/actions/runs/16126042891

**Special notes for your reviewer**:

We could maybe update one-by-one but I created one PR that we bump all,  Claude helped.
 
I am not aware if I could test it somehow (mabye in a dev branch)

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
