### PR TITLE
Fix unit tests failing due to outdated envtest 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,16 +58,42 @@ CONTROLLER_GEN=$(shell pwd)/_cache/controller-gen
 CONTROLLER_GEN_VERSION ?= v0.18.0
 CACHE_PATH=$(shell pwd)/_cache
 
-
-
 TESTS_REPORTS_PATH ?= /tmp/test_e2e_logs/
 VALIDATION_TESTS_REPORTS_PATH ?= /tmp/test_validation_logs/
 
-ENVTEST_ASSETS_DIR=$(shell pwd)/testbin
-test: generate fmt vet manifests ## Run unit and integration tests
-	mkdir -p ${ENVTEST_ASSETS_DIR}
-	test -f ${ENVTEST_ASSETS_DIR}/setup-envtest.sh || curl -sSLo ${ENVTEST_ASSETS_DIR}/setup-envtest.sh https://raw.githubusercontent.com/kubernetes-sigs/controller-runtime/v0.8.3/hack/setup-envtest.sh
-	source ${ENVTEST_ASSETS_DIR}/setup-envtest.sh; fetch_envtest_tools $(ENVTEST_ASSETS_DIR); setup_envtest_env $(ENVTEST_ASSETS_DIR); go test -race ./... -coverprofile cover.out
+# NOTE | TODO: switch to dynamic detection after bump to controller-runtime version >= release-0.19. Earlier versions
+# cannot be downloaded.
+#ENVTEST_VERSION is the version of controller-runtime release branch to fetch the envtest setup script (i.e. release-0.20)
+# ENVTEST_VERSION ?= $(shell go list -m -f "{{ .Version }}" sigs.k8s.io/controller-runtime | awk -F'[v.]' '{printf "release-%d.%d", $$2, $$3}')
+ENVTEST_VERSION ?= release-0.19
+# NOTE | TODO: switch to dynamic detection after bump to k8s version >= 1.31.0. With version 1.30, we currently see
+# ` undeclared reference to 'isCIDR'` due to templates using newer CEL rules.
+#ENVTEST_K8S_VERSION is the version of Kubernetes to use for setting up ENVTEST binaries (i.e. 1.31)
+# ENVTEST_K8S_VERSION ?= $(shell go list -m -f "{{ .Version }}" k8s.io/api | awk -F'[v.]' '{printf "1.%d", $$3}')
+ENVTEST_K8S_VERSION ?= 1.31
+
+ENVTEST_ASSETS_DIR ?= $(shell pwd)/testbin
+ENVTEST ?= $(ENVTEST_ASSETS_DIR)/setup-envtest
+
+$(ENVTEST_ASSETS_DIR):
+	mkdir -p $(ENVTEST_ASSETS_DIR)
+
+.PHONY: envtest
+envtest: $(ENVTEST) ## Download envtest-setup locally if necessary.
+$(ENVTEST): $(ENVTEST_ASSETS_DIR)
+	$(call go-install-tool,$(ENVTEST),sigs.k8s.io/controller-runtime/tools/setup-envtest,$(ENVTEST_VERSION))
+
+.PHONY: setup-envtest
+setup-envtest: setup-envtest ## Download the binaries required for ENVTEST in the local bin directory.
+	@echo "Setting up envtest binaries for Kubernetes version $(ENVTEST_K8S_VERSION)..."
+	@$(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(ENVTEST_ASSETS_DIR) -p path || { \
+		echo "Error: Failed to set up envtest binaries for version $(ENVTEST_K8S_VERSION)."; \
+		exit 1; \
+	}
+
+test: generate fmt vet manifests envtest ## Run unit and integration tests
+	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(ENVTEST_ASSETS_DIR) -p path)" \
+		go test -race ./... -coverprofile cover.out
 
 all: manager ## Default make target if no options specified
 
@@ -289,3 +315,19 @@ check_generated: ## Checks if there are any different with the current checkout
 help:  ## Show this help
 	@grep -F -h "##" $(MAKEFILE_LIST) | grep -F -v grep | sed -e 's/\\$$//' \
 		| awk -F'[:#]' '{print $$1 = sprintf("%-30s", $$1), $$4}'
+
+# go-install-tool will 'go install' any package with custom target and name of binary, if it doesn't exist
+# $1 - target path with name of binary
+# $2 - package url which can be installed
+# $3 - specific version of package
+define go-install-tool
+@[ -f "$(1)-$(3)" ] || { \
+set -e; \
+package=$(2)@$(3) ;\
+echo "Downloading $${package}" ;\
+rm -f $(1) || true ;\
+GOBIN=$(ENVTEST_ASSETS_DIR) go install $${package} ;\
+mv $(1) $(1)-$(3) ;\
+} ;\
+ln -sf $(1)-$(3) $(1)
+endef

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -49,10 +49,14 @@ const (
 // These tests use Ginkgo (BDD-style Go testing framework). Refer to
 // http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
 
-var cfg *rest.Config
-var k8sClient client.Client
-var testEnv *envtest.Environment
-var reconciler *MetalLBReconciler
+var (
+	cfg        *rest.Config
+	k8sClient  client.Client
+	testEnv    *envtest.Environment
+	reconciler *MetalLBReconciler
+	ctx        context.Context
+	cancel     context.CancelFunc
+)
 
 func TestAPIs(t *testing.T) {
 	RegisterFailHandler(Fail)
@@ -93,6 +97,7 @@ var defaultEnvConfig = params.EnvConfig{
 }
 var _ = BeforeSuite(func() {
 	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
+	ctx, cancel = context.WithCancel(context.TODO())
 
 	By("Setting MetalLBReconcilier environment variables")
 
@@ -134,7 +139,7 @@ var _ = BeforeSuite(func() {
 		},
 	}
 
-	err = k8sClient.Create(context.Background(), testNamespace)
+	err = k8sClient.Create(ctx, testNamespace)
 	Expect(err).ToNot(HaveOccurred())
 
 	MetalLBChartPath = MetalLBHelmChartPathControllerTest // This is needed as the tests need to reference a directory backward
@@ -151,13 +156,14 @@ var _ = BeforeSuite(func() {
 	Expect(err).ToNot(HaveOccurred())
 
 	go func() {
-		err = k8sManager.Start(ctrl.SetupSignalHandler())
+		err = k8sManager.Start(ctx)
 		Expect(err).ToNot(HaveOccurred())
 	}()
 })
 
 var _ = AfterSuite(func() {
 	By("tearing down the test environment")
+	cancel()
 	// restore Manifestpaths for both controller to their original value
 	MetalLBChartPath = MetalLBChartPathController
 	FRRK8SChartPath = FRRK8SChartPathController

--- a/hack/openshiftapicrds/networks.yaml
+++ b/hack/openshiftapicrds/networks.yaml
@@ -1,6 +1,11 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    api-approved.openshift.io: https://github.com/openshift/api/pull/475
+    api.openshift.io/merged-by-featuregates: "true"
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
   name: networks.operator.openshift.io
 spec:
   group: operator.openshift.io
@@ -14,20 +19,26 @@ spec:
   - name: v1
     schema:
       openAPIV3Schema:
-        description: "Network describes the cluster's desired network configuration.
-          It is consumed by the cluster-network-operator. \n Compatibility level 1:
-          Stable within a major release for a minimum of 12 months or 3 minor releases
-          (whichever is longer)."
+        description: |-
+          Network describes the cluster's desired network configuration. It is
+          consumed by the cluster-network-operator.
+
+          Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -35,73 +46,76 @@ spec:
             description: NetworkSpec is the top-level network configuration object.
             properties:
               additionalNetworks:
-                description: additionalNetworks is a list of extra networks to make
-                  available to pods when multiple networks are enabled.
+                description: |-
+                  additionalNetworks is a list of extra networks to make available to pods
+                  when multiple networks are enabled.
                 items:
-                  description: AdditionalNetworkDefinition configures an extra network
-                    that is available but not created by default. Instead, pods must
-                    request them by name. type must be specified, along with exactly
-                    one "Config" that matches the type.
+                  description: |-
+                    AdditionalNetworkDefinition configures an extra network that is available but not
+                    created by default. Instead, pods must request them by name.
+                    type must be specified, along with exactly one "Config" that matches the type.
                   properties:
                     name:
-                      description: name is the name of the network. This will be populated
-                        in the resulting CRD This must be unique.
+                      description: |-
+                        name is the name of the network. This will be populated in the resulting CRD
+                        This must be unique.
                       type: string
                     namespace:
-                      description: namespace is the namespace of the network. This
-                        will be populated in the resulting CRD If not given the network
-                        will be created in the default namespace.
+                      description: |-
+                        namespace is the namespace of the network. This will be populated in the resulting CRD
+                        If not given the network will be created in the default namespace.
                       type: string
                     rawCNIConfig:
-                      description: rawCNIConfig is the raw CNI configuration json
-                        to create in the NetworkAttachmentDefinition CRD
+                      description: |-
+                        rawCNIConfig is the raw CNI configuration json to create in the
+                        NetworkAttachmentDefinition CRD
                       type: string
                     simpleMacvlanConfig:
-                      description: SimpleMacvlanConfig configures the macvlan interface
+                      description: simpleMacvlanConfig configures the macvlan interface
                         in case of type:NetworkTypeSimpleMacvlan
                       properties:
                         ipamConfig:
-                          description: IPAMConfig configures IPAM module will be used
+                          description: ipamConfig configures IPAM module will be used
                             for IP Address Management (IPAM).
                           properties:
                             staticIPAMConfig:
-                              description: StaticIPAMConfig configures the static
+                              description: staticIPAMConfig configures the static
                                 IP address in case of type:IPAMTypeStatic
                               properties:
                                 addresses:
-                                  description: Addresses configures IP address for
+                                  description: addresses configures IP address for
                                     the interface
                                   items:
                                     description: StaticIPAMAddresses provides IP address
                                       and Gateway for static IPAM addresses
                                     properties:
                                       address:
-                                        description: Address is the IP address in
+                                        description: address is the IP address in
                                           CIDR format
                                         type: string
                                       gateway:
-                                        description: Gateway is IP inside of subnet
+                                        description: gateway is IP inside of subnet
                                           to designate as the gateway
                                         type: string
                                     type: object
                                   type: array
                                   x-kubernetes-list-type: atomic
                                 dns:
-                                  description: DNS configures DNS for the interface
+                                  description: dns configures DNS for the interface
                                   properties:
                                     domain:
-                                      description: Domain configures the domainname
+                                      description: domain configures the domainname
                                         the local domain used for short hostname lookups
                                       type: string
                                     nameservers:
-                                      description: Nameservers points DNS servers
+                                      description: nameservers points DNS servers
                                         for IP lookup
                                       items:
                                         type: string
                                       type: array
                                       x-kubernetes-list-type: atomic
                                     search:
-                                      description: Search configures priority ordered
+                                      description: search configures priority ordered
                                         search domains for short hostname lookups
                                       items:
                                         type: string
@@ -109,50 +123,52 @@ spec:
                                       x-kubernetes-list-type: atomic
                                   type: object
                                 routes:
-                                  description: Routes configures IP routes for the
+                                  description: routes configures IP routes for the
                                     interface
                                   items:
                                     description: StaticIPAMRoutes provides Destination/Gateway
                                       pairs for static IPAM routes
                                     properties:
                                       destination:
-                                        description: Destination points the IP route
+                                        description: destination points the IP route
                                           destination
                                         type: string
                                       gateway:
-                                        description: Gateway is the route's next-hop
-                                          IP address If unset, a default gateway is
-                                          assumed (as determined by the CNI plugin).
+                                        description: |-
+                                          gateway is the route's next-hop IP address
+                                          If unset, a default gateway is assumed (as determined by the CNI plugin).
                                         type: string
                                     type: object
                                   type: array
                                   x-kubernetes-list-type: atomic
                               type: object
                             type:
-                              description: Type is the type of IPAM module will be
-                                used for IP Address Management(IPAM). The supported
-                                values are IPAMTypeDHCP, IPAMTypeStatic
+                              description: |-
+                                type is the type of IPAM module will be used for IP Address Management(IPAM).
+                                The supported values are IPAMTypeDHCP, IPAMTypeStatic
                               type: string
                           type: object
                         master:
-                          description: master is the host interface to create the
-                            macvlan interface from. If not specified, it will be default
-                            route interface
+                          description: |-
+                            master is the host interface to create the macvlan interface from.
+                            If not specified, it will be default route interface
                           type: string
                         mode:
                           description: 'mode is the macvlan mode: bridge, private,
                             vepa, passthru. The default is bridge'
                           type: string
                         mtu:
-                          description: mtu is the mtu to use for the macvlan interface.
-                            if unset, host's kernel will select the value.
+                          description: |-
+                            mtu is the mtu to use for the macvlan interface. if unset, host's
+                            kernel will select the value.
                           format: int32
                           minimum: 0
                           type: integer
                       type: object
                     type:
-                      description: type is the type of network The supported values
-                        are NetworkTypeRaw, NetworkTypeSimpleMacvlan
+                      description: |-
+                        type is the type of network
+                        The supported values are NetworkTypeRaw, NetworkTypeSimpleMacvlan
                       type: string
                   required:
                   - name
@@ -162,22 +178,23 @@ spec:
                 - name
                 x-kubernetes-list-type: map
               additionalRoutingCapabilities:
-                description: additionalRoutingCapabilities describes components and
-                  relevant configuration providing additional routing capabilities.
-                  When set, it enables such components and the usage of the routing
-                  capabilities they provide for the machine network. Upstream operators,
-                  like MetalLB operator, requiring these capabilities may rely on,
-                  or automatically set this attribute. Network plugins may leverage
-                  advanced routing capabilities acquired through the enablement of
-                  these components but may require specific configuration on their
-                  side to do so; refer to their respective documentation and configuration
-                  options.
+                description: |-
+                  additionalRoutingCapabilities describes components and relevant
+                  configuration providing additional routing capabilities. When set, it
+                  enables such components and the usage of the routing capabilities they
+                  provide for the machine network. Upstream operators, like MetalLB
+                  operator, requiring these capabilities may rely on, or automatically set
+                  this attribute. Network plugins may leverage advanced routing
+                  capabilities acquired through the enablement of these components but may
+                  require specific configuration on their side to do so; refer to their
+                  respective documentation and configuration options.
                 properties:
                   providers:
-                    description: providers is a set of enabled components that provide
-                      additional routing capabilities. Entries on this list must be
-                      unique. The  only valid value is currrently "FRR" which provides
-                      FRR routing capabilities through the deployment of FRR.
+                    description: |-
+                      providers is a set of enabled components that provide additional routing
+                      capabilities. Entries on this list must be unique. The  only valid value
+                      is currrently "FRR" which provides FRR routing capabilities through the
+                      deployment of FRR.
                     items:
                       description: RoutingCapabilitiesProvider is a component providing
                         routing capabilities.
@@ -194,16 +211,16 @@ spec:
                 - providers
                 type: object
               clusterNetwork:
-                description: clusterNetwork is the IP address pool to use for pod
-                  IPs. Some network providers, e.g. OpenShift SDN, support multiple
-                  ClusterNetworks. Others only support one. This is equivalent to
-                  the cluster-cidr.
+                description: |-
+                  clusterNetwork is the IP address pool to use for pod IPs.
+                  Some network providers support multiple ClusterNetworks.
+                  Others only support one. This is equivalent to the cluster-cidr.
                 items:
-                  description: ClusterNetworkEntry is a subnet from which to allocate
-                    PodIPs. A network of size HostPrefix (in CIDR notation) will be
-                    allocated when nodes join the cluster. If the HostPrefix field
-                    is not used by the plugin, it can be left unset. Not all network
-                    providers support multiple ClusterNetworks
+                  description: |-
+                    ClusterNetworkEntry is a subnet from which to allocate PodIPs. A network of size
+                    HostPrefix (in CIDR notation) will be allocated when nodes join the cluster. If
+                    the HostPrefix field is not used by the plugin, it can be left unset.
+                    Not all network providers support multiple ClusterNetworks
                   properties:
                     cidr:
                       type: string
@@ -219,29 +236,30 @@ spec:
                   will receive
                 properties:
                   openshiftSDNConfig:
-                    description: openShiftSDNConfig configures the openshift-sdn plugin
+                    description: |-
+                      openshiftSDNConfig was previously used to configure the openshift-sdn plugin.
+                      DEPRECATED: OpenShift SDN is no longer supported.
                     properties:
                       enableUnidling:
-                        description: enableUnidling controls whether or not the service
-                          proxy will support idling and unidling of services. By default,
-                          unidling is enabled.
+                        description: |-
+                          enableUnidling controls whether or not the service proxy will support idling
+                          and unidling of services. By default, unidling is enabled.
                         type: boolean
                       mode:
                         description: mode is one of "Multitenant", "Subnet", or "NetworkPolicy"
                         type: string
                       mtu:
-                        description: mtu is the mtu to use for the tunnel interface.
-                          Defaults to 1450 if unset. This must be 50 bytes smaller
-                          than the machine's uplink.
+                        description: |-
+                          mtu is the mtu to use for the tunnel interface. Defaults to 1450 if unset.
+                          This must be 50 bytes smaller than the machine's uplink.
                         format: int32
                         minimum: 0
                         type: integer
                       useExternalOpenvswitch:
-                        description: 'useExternalOpenvswitch used to control whether
-                          the operator would deploy an OVS DaemonSet itself or expect
-                          someone else to start OVS. As of 4.6, OVS is always run
-                          as a system service, and this flag is ignored. DEPRECATED:
-                          non-functional as of 4.6'
+                        description: |-
+                          useExternalOpenvswitch used to control whether the operator would deploy an OVS
+                          DaemonSet itself or expect someone else to start OVS. As of 4.6, OVS is always
+                          run as a system service, and this flag is ignored.
                         type: boolean
                       vxlanPort:
                         description: vxlanPort is the port to use for all vxlan packets.
@@ -259,18 +277,14 @@ spec:
                           options.
                         properties:
                           reachabilityTotalTimeoutSeconds:
-                            description: reachabilityTotalTimeout configures the EgressIP
-                              node reachability check total timeout in seconds. If
-                              the EgressIP node cannot be reached within this timeout,
-                              the node is declared down. Setting a large value may
-                              cause the EgressIP feature to react slowly to node changes.
-                              In particular, it may react slowly for EgressIP nodes
-                              that really have a genuine problem and are unreachable.
-                              When omitted, this means the user has no opinion and
-                              the platform is left to choose a reasonable default,
-                              which is subject to change over time. The current default
-                              is 1 second. A value of 0 disables the EgressIP node's
-                              reachability check.
+                            description: |-
+                              reachabilityTotalTimeout configures the EgressIP node reachability check total timeout in seconds.
+                              If the EgressIP node cannot be reached within this timeout, the node is declared down.
+                              Setting a large value may cause the EgressIP feature to react slowly to node changes.
+                              In particular, it may react slowly for EgressIP nodes that really have a genuine problem and are unreachable.
+                              When omitted, this means the user has no opinion and the platform is left to choose a reasonable default, which is subject to change over time.
+                              The current default is 1 second.
+                              A value of 0 disables the EgressIP node's reachability check.
                             format: int32
                             maximum: 60
                             minimum: 0
@@ -281,37 +295,28 @@ spec:
                           gateway options.
                         properties:
                           ipForwarding:
-                            description: IPForwarding controls IP forwarding for all
-                              traffic on OVN-Kubernetes managed interfaces (such as
-                              br-ex). By default this is set to Restricted, and Kubernetes
-                              related traffic is still forwarded appropriately, but
-                              other IP traffic will not be routed by the OCP node.
-                              If there is a desire to allow the host to forward traffic
-                              across OVN-Kubernetes managed interfaces, then set this
-                              field to "Global". The supported values are "Restricted"
-                              and "Global".
+                            description: |-
+                              ipForwarding controls IP forwarding for all traffic on OVN-Kubernetes managed interfaces (such as br-ex).
+                              By default this is set to Restricted, and Kubernetes related traffic is still forwarded appropriately, but other
+                              IP traffic will not be routed by the OCP node. If there is a desire to allow the host to forward traffic across
+                              OVN-Kubernetes managed interfaces, then set this field to "Global".
+                              The supported values are "Restricted" and "Global".
                             type: string
                           ipv4:
-                            description: ipv4 allows users to configure IP settings
-                              for IPv4 connections. When omitted, this means no opinion
-                              and the default configuration is used. Check individual
-                              members fields within ipv4 for details of default values.
+                            description: |-
+                              ipv4 allows users to configure IP settings for IPv4 connections. When omitted, this means no opinion and the default
+                              configuration is used. Check individual members fields within ipv4 for details of default values.
                             properties:
                               internalMasqueradeSubnet:
-                                description: internalMasqueradeSubnet contains the
-                                  masquerade addresses in IPV4 CIDR format used internally
-                                  by ovn-kubernetes to enable host to service traffic.
-                                  Each host in the cluster is configured with these
-                                  addresses, as well as the shared gateway bridge
-                                  interface. The values can be changed after installation.
-                                  The subnet chosen should not overlap with other
-                                  networks specified for OVN-Kubernetes as well as
-                                  other networks used on the host. Additionally the
-                                  subnet must be large enough to accommodate 6 IPs
-                                  (maximum prefix length /29). When omitted, this
-                                  means no opinion and the platform is left to choose
-                                  a reasonable default which is subject to change
-                                  over time. The current default subnet is 169.254.169.0/29
+                                description: |-
+                                  internalMasqueradeSubnet contains the masquerade addresses in IPV4 CIDR format used internally by
+                                  ovn-kubernetes to enable host to service traffic. Each host in the cluster is configured with these
+                                  addresses, as well as the shared gateway bridge interface. The values can be changed after
+                                  installation. The subnet chosen should not overlap with other networks specified for
+                                  OVN-Kubernetes as well as other networks used on the host. Additionally the subnet must
+                                  be large enough to accommodate 6 IPs (maximum prefix length /29).
+                                  When omitted, this means no opinion and the platform is left to choose a reasonable default which is subject to change over time.
+                                  The current default subnet is 169.254.0.0/17
                                   The value must be in proper IPV4 CIDR format
                                 maxLength: 18
                                 type: string
@@ -327,26 +332,20 @@ spec:
                                     0
                             type: object
                           ipv6:
-                            description: ipv6 allows users to configure IP settings
-                              for IPv6 connections. When omitted, this means no opinion
-                              and the default configuration is used. Check individual
-                              members fields within ipv6 for details of default values.
+                            description: |-
+                              ipv6 allows users to configure IP settings for IPv6 connections. When omitted, this means no opinion and the default
+                              configuration is used. Check individual members fields within ipv6 for details of default values.
                             properties:
                               internalMasqueradeSubnet:
-                                description: internalMasqueradeSubnet contains the
-                                  masquerade addresses in IPV6 CIDR format used internally
-                                  by ovn-kubernetes to enable host to service traffic.
-                                  Each host in the cluster is configured with these
-                                  addresses, as well as the shared gateway bridge
-                                  interface. The values can be changed after installation.
-                                  The subnet chosen should not overlap with other
-                                  networks specified for OVN-Kubernetes as well as
-                                  other networks used on the host. Additionally the
-                                  subnet must be large enough to accommodate 6 IPs
-                                  (maximum prefix length /125). When omitted, this
-                                  means no opinion and the platform is left to choose
-                                  a reasonable default which is subject to change
-                                  over time. The current default subnet is fd69::/125
+                                description: |-
+                                  internalMasqueradeSubnet contains the masquerade addresses in IPV6 CIDR format used internally by
+                                  ovn-kubernetes to enable host to service traffic. Each host in the cluster is configured with these
+                                  addresses, as well as the shared gateway bridge interface. The values can be changed after
+                                  installation. The subnet chosen should not overlap with other networks specified for
+                                  OVN-Kubernetes as well as other networks used on the host. Additionally the subnet must
+                                  be large enough to accommodate 6 IPs (maximum prefix length /125).
+                                  When omitted, this means no opinion and the platform is left to choose a reasonable default which is subject to change over time.
+                                  The current default subnet is fd69::/112
                                   Note that IPV6 dual addresses are not permitted
                                 type: string
                                 x-kubernetes-validations:
@@ -360,35 +359,34 @@ spec:
                             type: object
                           routingViaHost:
                             default: false
-                            description: RoutingViaHost allows pod egress traffic
-                              to exit via the ovn-k8s-mp0 management port into the
-                              host before sending it out. If this is not set, traffic
-                              will always egress directly from OVN to outside without
-                              touching the host stack. Setting this to true means
-                              hardware offload will not be supported. Default is false
-                              if GatewayConfig is specified.
+                            description: |-
+                              routingViaHost allows pod egress traffic to exit via the ovn-k8s-mp0 management port
+                              into the host before sending it out. If this is not set, traffic will always egress directly
+                              from OVN to outside without touching the host stack. Setting this to true means hardware
+                              offload will not be supported. Default is false if GatewayConfig is specified.
                             type: boolean
                         type: object
                       genevePort:
-                        description: geneve port is the UDP port to be used by geneve
-                          encapulation. Default is 6081
+                        description: |-
+                          geneve port is the UDP port to be used by geneve encapulation.
+                          Default is 6081
                         format: int32
                         minimum: 1
                         type: integer
                       hybridOverlayConfig:
-                        description: HybridOverlayConfig configures an additional
-                          overlay network for peers that are not using OVN.
+                        description: |-
+                          hybridOverlayConfig configures an additional overlay network for peers that are
+                          not using OVN.
                         properties:
                           hybridClusterNetwork:
-                            description: HybridClusterNetwork defines a network space
+                            description: hybridClusterNetwork defines a network space
                               given to nodes on an additional overlay network.
                             items:
-                              description: ClusterNetworkEntry is a subnet from which
-                                to allocate PodIPs. A network of size HostPrefix (in
-                                CIDR notation) will be allocated when nodes join the
-                                cluster. If the HostPrefix field is not used by the
-                                plugin, it can be left unset. Not all network providers
-                                support multiple ClusterNetworks
+                              description: |-
+                                ClusterNetworkEntry is a subnet from which to allocate PodIPs. A network of size
+                                HostPrefix (in CIDR notation) will be allocated when nodes join the cluster. If
+                                the HostPrefix field is not used by the plugin, it can be left unset.
+                                Not all network providers support multiple ClusterNetworks
                               properties:
                                 cidr:
                                   type: string
@@ -400,8 +398,8 @@ spec:
                             type: array
                             x-kubernetes-list-type: atomic
                           hybridOverlayVXLANPort:
-                            description: HybridOverlayVXLANPort defines the VXLAN
-                              port number to be used by the additional overlay network.
+                            description: |-
+                              hybridOverlayVXLANPort defines the VXLAN port number to be used by the additional overlay network.
                               Default is 4789
                             format: int32
                             type: integer
@@ -409,23 +407,42 @@ spec:
                       ipsecConfig:
                         default:
                           mode: Disabled
-                        description: ipsecConfig enables and configures IPsec for
-                          pods on the pod network within the cluster.
+                        description: |-
+                          ipsecConfig enables and configures IPsec for pods on the pod network within the
+                          cluster.
                         properties:
+                          full:
+                            description: |-
+                              full defines configuration parameters for the IPsec `Full` mode.
+                              This is permitted only when mode is configured with `Full`,
+                              and forbidden otherwise.
+                            minProperties: 1
+                            properties:
+                              encapsulation:
+                                description: |-
+                                  encapsulation option to configure libreswan on how inter-pod traffic across nodes
+                                  are encapsulated to handle NAT traversal. When configured it uses UDP port 4500
+                                  for the encapsulation.
+                                  Valid values are Always, Auto and omitted.
+                                  Always means enable UDP encapsulation regardless of whether NAT is detected.
+                                  Auto means enable UDP encapsulation based on the detection of NAT.
+                                  When omitted, this means no opinion and the platform is left to choose a reasonable
+                                  default, which is subject to change over time. The current default is Auto.
+                                enum:
+                                - Always
+                                - Auto
+                                type: string
+                            type: object
                           mode:
-                            description: mode defines the behaviour of the ipsec configuration
-                              within the platform. Valid values are `Disabled`, `External`
-                              and `Full`. When 'Disabled', ipsec will not be enabled
-                              at the node level. When 'External', ipsec is enabled
-                              on the node level but requires the user to configure
-                              the secure communication parameters. This mode is for
-                              external secure communications and the configuration
-                              can be done using the k8s-nmstate operator. When 'Full',
-                              ipsec is configured on the node level and inter-pod
-                              secure communication within the cluster is configured.
-                              Note with `Full`, if ipsec is desired for communication
-                              with external (to the cluster) entities (such as storage
-                              arrays), this is left to the user to configure.
+                            description: |-
+                              mode defines the behaviour of the ipsec configuration within the platform.
+                              Valid values are `Disabled`, `External` and `Full`.
+                              When 'Disabled', ipsec will not be enabled at the node level.
+                              When 'External', ipsec is enabled on the node level but requires the user to configure the secure communication parameters.
+                              This mode is for external secure communications and the configuration can be done using the k8s-nmstate operator.
+                              When 'Full', ipsec is configured on the node level and inter-pod secure communication within the cluster is configured.
+                              Note with `Full`, if ipsec is desired for communication with external (to the cluster) entities (such as storage arrays),
+                              this is left to the user to configure.
                             enum:
                             - Disabled
                             - External
@@ -435,23 +452,24 @@ spec:
                         x-kubernetes-validations:
                         - message: ipsecConfig.mode is required
                           rule: self == oldSelf || has(self.mode)
+                        - message: full is forbidden when mode is not Full
+                          rule: 'has(self.mode) && self.mode == ''Full'' ?  true :
+                            !has(self.full)'
                       ipv4:
-                        description: ipv4 allows users to configure IP settings for
-                          IPv4 connections. When ommitted, this means no opinions
-                          and the default configuration is used. Check individual
+                        description: |-
+                          ipv4 allows users to configure IP settings for IPv4 connections. When ommitted,
+                          this means no opinions and the default configuration is used. Check individual
                           fields within ipv4 for details of default values.
                         properties:
                           internalJoinSubnet:
-                            description: internalJoinSubnet is a v4 subnet used internally
-                              by ovn-kubernetes in case the default one is being already
-                              used by something else. It must not overlap with any
-                              other subnet being used by OpenShift or by the node
-                              network. The size of the subnet must be larger than
-                              the number of nodes. The value cannot be changed after
-                              installation. The current default value is 100.64.0.0/16
-                              The subnet must be large enough to accomadate one IP
-                              per node in your cluster The value must be in proper
-                              IPV4 CIDR format
+                            description: |-
+                              internalJoinSubnet is a v4 subnet used internally by ovn-kubernetes in case the
+                              default one is being already used by something else. It must not overlap with
+                              any other subnet being used by OpenShift or by the node network. The size of the
+                              subnet must be larger than the number of nodes.
+                              The current default value is 100.64.0.0/16
+                              The subnet must be large enough to accommodate one IP per node in your cluster
+                              The value must be in proper IPV4 CIDR format
                             maxLength: 18
                             type: string
                             x-kubernetes-validations:
@@ -462,20 +480,17 @@ spec:
                             - message: first IP address octet must not be 0
                               rule: isCIDR(self) && int(self.split('.')[0]) > 0
                           internalTransitSwitchSubnet:
-                            description: internalTransitSwitchSubnet is a v4 subnet
-                              in IPV4 CIDR format used internally by OVN-Kubernetes
-                              for the distributed transit switch in the OVN Interconnect
-                              architecture that connects the cluster routers on each
-                              node together to enable east west traffic. The subnet
-                              chosen should not overlap with other networks specified
-                              for OVN-Kubernetes as well as other networks used on
-                              the host. The value cannot be changed after installation.
-                              When ommitted, this means no opinion and the platform
-                              is left to choose a reasonable default which is subject
-                              to change over time. The current default subnet is 100.88.0.0/16
-                              The subnet must be large enough to accomadate one IP
-                              per node in your cluster The value must be in proper
-                              IPV4 CIDR format
+                            description: |-
+                              internalTransitSwitchSubnet is a v4 subnet in IPV4 CIDR format used internally
+                              by OVN-Kubernetes for the distributed transit switch in the OVN Interconnect
+                              architecture that connects the cluster routers on each node together to enable
+                              east west traffic. The subnet chosen should not overlap with other networks
+                              specified for OVN-Kubernetes as well as other networks used on the host.
+                              When ommitted, this means no opinion and the platform is left to choose a reasonable
+                              default which is subject to change over time.
+                              The current default subnet is 100.88.0.0/16
+                              The subnet must be large enough to accommodate one IP per node in your cluster
+                              The value must be in proper IPV4 CIDR format
                             maxLength: 18
                             type: string
                             x-kubernetes-validations:
@@ -487,22 +502,21 @@ spec:
                               rule: isCIDR(self) && int(self.split('.')[0]) > 0
                         type: object
                       ipv6:
-                        description: ipv6 allows users to configure IP settings for
-                          IPv6 connections. When ommitted, this means no opinions
-                          and the default configuration is used. Check individual
+                        description: |-
+                          ipv6 allows users to configure IP settings for IPv6 connections. When ommitted,
+                          this means no opinions and the default configuration is used. Check individual
                           fields within ipv4 for details of default values.
                         properties:
                           internalJoinSubnet:
-                            description: internalJoinSubnet is a v6 subnet used internally
-                              by ovn-kubernetes in case the default one is being already
-                              used by something else. It must not overlap with any
-                              other subnet being used by OpenShift or by the node
-                              network. The size of the subnet must be larger than
-                              the number of nodes. The value cannot be changed after
-                              installation. The subnet must be large enough to accomadate
-                              one IP per node in your cluster The current default
-                              value is fd98::/48 The value must be in proper IPV6
-                              CIDR format Note that IPV6 dual addresses are not permitted
+                            description: |-
+                              internalJoinSubnet is a v6 subnet used internally by ovn-kubernetes in case the
+                              default one is being already used by something else. It must not overlap with
+                              any other subnet being used by OpenShift or by the node network. The size of the
+                              subnet must be larger than the number of nodes.
+                              The subnet must be large enough to accommodate one IP per node in your cluster
+                              The current default value is fd98::/64
+                              The value must be in proper IPV6 CIDR format
+                              Note that IPV6 dual addresses are not permitted
                             maxLength: 48
                             type: string
                             x-kubernetes-validations:
@@ -511,21 +525,18 @@ spec:
                             - message: subnet must be in the range /0 to /125 inclusive
                               rule: isCIDR(self) && cidr(self).prefixLength() <= 125
                           internalTransitSwitchSubnet:
-                            description: internalTransitSwitchSubnet is a v4 subnet
-                              in IPV4 CIDR format used internally by OVN-Kubernetes
-                              for the distributed transit switch in the OVN Interconnect
-                              architecture that connects the cluster routers on each
-                              node together to enable east west traffic. The subnet
-                              chosen should not overlap with other networks specified
-                              for OVN-Kubernetes as well as other networks used on
-                              the host. The value cannot be changed after installation.
-                              When ommitted, this means no opinion and the platform
-                              is left to choose a reasonable default which is subject
-                              to change over time. The subnet must be large enough
-                              to accomadate one IP per node in your cluster The current
-                              default subnet is fd97::/64 The value must be in proper
-                              IPV6 CIDR format Note that IPV6 dual addresses are not
-                              permitted
+                            description: |-
+                              internalTransitSwitchSubnet is a v4 subnet in IPV4 CIDR format used internally
+                              by OVN-Kubernetes for the distributed transit switch in the OVN Interconnect
+                              architecture that connects the cluster routers on each node together to enable
+                              east west traffic. The subnet chosen should not overlap with other networks
+                              specified for OVN-Kubernetes as well as other networks used on the host.
+                              When ommitted, this means no opinion and the platform is left to choose a reasonable
+                              default which is subject to change over time.
+                              The subnet must be large enough to accommodate one IP per node in your cluster
+                              The current default subnet is fd97::/64
+                              The value must be in proper IPV6 CIDR format
+                              Note that IPV6 dual addresses are not permitted
                             maxLength: 48
                             type: string
                             x-kubernetes-validations:
@@ -535,33 +546,36 @@ spec:
                               rule: isCIDR(self) && cidr(self).prefixLength() <= 125
                         type: object
                       mtu:
-                        description: mtu is the MTU to use for the tunnel interface.
-                          This must be 100 bytes smaller than the uplink mtu. Default
-                          is 1400
+                        description: |-
+                          mtu is the MTU to use for the tunnel interface. This must be 100
+                          bytes smaller than the uplink mtu.
+                          Default is 1400
                         format: int32
                         minimum: 0
                         type: integer
                       policyAuditConfig:
-                        description: policyAuditConfig is the configuration for network
-                          policy audit events. If unset, reported defaults are used.
+                        description: |-
+                          policyAuditConfig is the configuration for network policy audit events. If unset,
+                          reported defaults are used.
                         properties:
                           destination:
                             default: "null"
-                            description: 'destination is the location for policy log
-                              messages. Regardless of this config, persistent logs
-                              will always be dumped to the host at /var/log/ovn/ however
+                            description: |-
+                              destination is the location for policy log messages.
+                              Regardless of this config, persistent logs will always be dumped to the host
+                              at /var/log/ovn/ however
                               Additionally syslog output may be configured as follows.
-                              Valid values are: - "libc" -> to use the libc syslog()
-                              function of the host node''s journdald process - "udp:host:port"
-                              -> for sending syslog over UDP - "unix:file" -> for
-                              using the UNIX domain socket directly - "null" -> to
-                              discard all messages logged to syslog The default is
-                              "null"'
+                              Valid values are:
+                              - "libc" -> to use the libc syslog() function of the host node's journdald process
+                              - "udp:host:port" -> for sending syslog over UDP
+                              - "unix:file" -> for using the UNIX domain socket directly
+                              - "null" -> to discard all messages logged to syslog
+                              The default is "null"
                             type: string
                           maxFileSize:
                             default: 50
-                            description: maxFilesSize is the max size an ACL_audit
-                              log file is allowed to reach before rotation occurs
+                            description: |-
+                              maxFilesSize is the max size an ACL_audit log file is allowed to reach before rotation occurs
                               Units are in MB and the Default is 50MB
                             format: int32
                             minimum: 1
@@ -575,9 +589,9 @@ spec:
                             type: integer
                           rateLimit:
                             default: 20
-                            description: rateLimit is the approximate maximum number
-                              of messages to generate per-second per-node. If unset
-                              the default of 20 msg/sec is used.
+                            description: |-
+                              rateLimit is the approximate maximum number of messages to generate per-second per-node. If
+                              unset the default of 20 msg/sec is used.
                             format: int32
                             minimum: 1
                             type: integer
@@ -587,55 +601,73 @@ spec:
                               messages, e.g. "kern". Default is "local0"
                             type: string
                         type: object
+                      routeAdvertisements:
+                        description: |-
+                          routeAdvertisements determines if the functionality to advertise cluster
+                          network routes through a dynamic routing protocol, such as BGP, is
+                          enabled or not. This functionality is configured through the
+                          ovn-kubernetes RouteAdvertisements CRD. Requires the 'FRR' routing
+                          capability provider to be enabled as an additional routing capability.
+                          Allowed values are "Enabled", "Disabled" and ommited. When omitted, this
+                          means the user has no opinion and the platform is left to choose
+                          reasonable defaults. These defaults are subject to change over time. The
+                          current default is "Disabled".
+                        enum:
+                        - ""
+                        - Enabled
+                        - Disabled
+                        type: string
                       v4InternalSubnet:
-                        description: v4InternalSubnet is a v4 subnet used internally
-                          by ovn-kubernetes in case the default one is being already
-                          used by something else. It must not overlap with any other
-                          subnet being used by OpenShift or by the node network. The
-                          size of the subnet must be larger than the number of nodes.
-                          The value cannot be changed after installation. Default
-                          is 100.64.0.0/16
+                        description: |-
+                          v4InternalSubnet is a v4 subnet used internally by ovn-kubernetes in case the
+                          default one is being already used by something else. It must not overlap with
+                          any other subnet being used by OpenShift or by the node network. The size of the
+                          subnet must be larger than the number of nodes.
+                          Default is 100.64.0.0/16
                         type: string
                       v6InternalSubnet:
-                        description: v6InternalSubnet is a v6 subnet used internally
-                          by ovn-kubernetes in case the default one is being already
-                          used by something else. It must not overlap with any other
-                          subnet being used by OpenShift or by the node network. The
-                          size of the subnet must be larger than the number of nodes.
-                          The value cannot be changed after installation. Default
-                          is fd98::/48
+                        description: |-
+                          v6InternalSubnet is a v6 subnet used internally by ovn-kubernetes in case the
+                          default one is being already used by something else. It must not overlap with
+                          any other subnet being used by OpenShift or by the node network. The size of the
+                          subnet must be larger than the number of nodes.
+                          Default is fd98::/64
                         type: string
                     type: object
                   type:
-                    description: type is the type of network All NetworkTypes are
-                      supported except for NetworkTypeRaw
+                    description: |-
+                      type is the type of network
+                      All NetworkTypes are supported except for NetworkTypeRaw
                     type: string
                 type: object
               deployKubeProxy:
-                description: deployKubeProxy specifies whether or not a standalone
-                  kube-proxy should be deployed by the operator. Some network providers
-                  include kube-proxy or similar functionality. If unset, the plugin
-                  will attempt to select the correct value, which is false when OpenShift
-                  SDN and ovn-kubernetes are used and true otherwise.
+                description: |-
+                  deployKubeProxy specifies whether or not a standalone kube-proxy should
+                  be deployed by the operator. Some network providers include kube-proxy
+                  or similar functionality. If unset, the plugin will attempt to select
+                  the correct value, which is false when ovn-kubernetes is used and true
+                  otherwise.
                 type: boolean
               disableMultiNetwork:
-                description: disableMultiNetwork specifies whether or not multiple
-                  pod network support should be disabled. If unset, this property
-                  defaults to 'false' and multiple network support is enabled.
+                description: |-
+                  disableMultiNetwork defaults to 'false' and this setting enables the pod multi-networking capability.
+                  disableMultiNetwork when set to 'true' at cluster install time does not install the components, typically the Multus CNI and the network-attachment-definition CRD,
+                  that enable the pod multi-networking capability. Setting the parameter to 'true' might be useful when you need install third-party CNI plugins,
+                  but these plugins are not supported by Red Hat. Changing the parameter value as a postinstallation cluster task has no effect.
                 type: boolean
               disableNetworkDiagnostics:
                 default: false
-                description: disableNetworkDiagnostics specifies whether or not PodNetworkConnectivityCheck
-                  CRs from a test pod to every node, apiserver and LB should be disabled
-                  or not. If unset, this property defaults to 'false' and network
-                  diagnostics is enabled. Setting this to 'true' would reduce the
-                  additional load of the pods performing the checks.
+                description: |-
+                  disableNetworkDiagnostics specifies whether or not PodNetworkConnectivityCheck
+                  CRs from a test pod to every node, apiserver and LB should be disabled or not.
+                  If unset, this property defaults to 'false' and network diagnostics is enabled.
+                  Setting this to 'true' would reduce the additional load of the pods performing the checks.
                 type: boolean
               exportNetworkFlows:
-                description: exportNetworkFlows enables and configures the export
-                  of network flow metadata from the pod network by using protocols
-                  NetFlow, SFlow or IPFIX. Currently only supported on OVN-Kubernetes
-                  plugin. If unset, flows will not be exported to any collector.
+                description: |-
+                  exportNetworkFlows enables and configures the export of network flow metadata from the pod network
+                  by using protocols NetFlow, SFlow or IPFIX. Currently only supported on OVN-Kubernetes plugin.
+                  If unset, flows will not be exported to any collector.
                 properties:
                   ipfix:
                     description: ipfix defines IPFIX configuration.
@@ -655,9 +687,9 @@ spec:
                     description: netFlow defines the NetFlow configuration.
                     properties:
                       collectors:
-                        description: netFlow defines the NetFlow collectors that will
-                          consume the flow data exported from OVS. It is a list of
-                          strings formatted as ip:port with a maximum of ten items
+                        description: |-
+                          netFlow defines the NetFlow collectors that will consume the flow data exported from OVS.
+                          It is a list of strings formatted as ip:port with a maximum of ten items
                         items:
                           pattern: ^(([0-9]|[0-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[0-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5]):([1-9][0-9]{0,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])$
                           type: string
@@ -682,20 +714,22 @@ spec:
                     type: object
                 type: object
               kubeProxyConfig:
-                description: kubeProxyConfig lets us configure desired proxy configuration.
-                  If not specified, sensible defaults will be chosen by OpenShift
-                  directly. Not consumed by all network providers - currently only
-                  openshift-sdn.
+                description: |-
+                  kubeProxyConfig lets us configure desired proxy configuration, if
+                  deployKubeProxy is true. If not specified, sensible defaults will be chosen by
+                  OpenShift directly.
                 properties:
                   bindAddress:
-                    description: The address to "bind" on Defaults to 0.0.0.0
+                    description: |-
+                      The address to "bind" on
+                      Defaults to 0.0.0.0
                     type: string
                   iptablesSyncPeriod:
-                    description: 'An internal kube-proxy parameter. In older releases
-                      of OCP, this sometimes needed to be adjusted in large clusters
-                      for performance reasons, but this is no longer necessary, and
-                      there is no reason to change this from the default value. Default:
-                      30s'
+                    description: |-
+                      An internal kube-proxy parameter. In older releases of OCP, this sometimes needed to be adjusted
+                      in large clusters for performance reasons, but this is no longer necessary, and there is no reason
+                      to change this from the default value.
+                      Default: 30s
                     type: string
                   proxyArguments:
                     additionalProperties:
@@ -711,11 +745,12 @@ spec:
                 type: object
               logLevel:
                 default: Normal
-                description: "logLevel is an intent based logging for an overall component.
-                  \ It does not give fine grained control, but it is a simple way
-                  to manage coarse grained logging choices that operators have to
-                  interpret for their operands. \n Valid values are: \"Normal\", \"Debug\",
-                  \"Trace\", \"TraceAll\". Defaults to \"Normal\"."
+                description: |-
+                  logLevel is an intent based logging for an overall component.  It does not give fine grained control, but it is a
+                  simple way to manage coarse grained logging choices that operators have to interpret for their operands.
+
+                  Valid values are: "Normal", "Debug", "Trace", "TraceAll".
+                  Defaults to "Normal".
                 enum:
                 - ""
                 - Normal
@@ -729,66 +764,59 @@ spec:
                 pattern: ^(Managed|Unmanaged|Force|Removed)$
                 type: string
               migration:
-                description: migration enables and configures the cluster network
-                  migration. The migration procedure allows to change the network
-                  type and the MTU.
+                description: |-
+                  migration enables and configures cluster network migration, for network changes
+                  that cannot be made instantly.
                 properties:
                   features:
-                    description: features contains the features migration configuration.
-                      Set this to migrate feature configuration when changing the
-                      cluster default network provider. if unset, the default operation
-                      is to migrate all the configuration of supported features.
+                    description: |-
+                      features was previously used to configure which network plugin features
+                      would be migrated in a network type migration.
+                      DEPRECATED: network type migration is no longer supported, and setting
+                      this to a non-empty value will result in the network operator rejecting
+                      the configuration.
                     properties:
                       egressFirewall:
                         default: true
-                        description: egressFirewall specifies whether or not the Egress
-                          Firewall configuration is migrated automatically when changing
-                          the cluster default network provider. If unset, this property
-                          defaults to 'true' and Egress Firewall configure is migrated.
+                        description: |-
+                          egressFirewall specified whether or not the Egress Firewall configuration was migrated.
+                          DEPRECATED: network type migration is no longer supported.
                         type: boolean
                       egressIP:
                         default: true
-                        description: egressIP specifies whether or not the Egress
-                          IP configuration is migrated automatically when changing
-                          the cluster default network provider. If unset, this property
-                          defaults to 'true' and Egress IP configure is migrated.
+                        description: |-
+                          egressIP specified whether or not the Egress IP configuration was migrated.
+                          DEPRECATED: network type migration is no longer supported.
                         type: boolean
                       multicast:
                         default: true
-                        description: multicast specifies whether or not the multicast
-                          configuration is migrated automatically when changing the
-                          cluster default network provider. If unset, this property
-                          defaults to 'true' and multicast configure is migrated.
+                        description: |-
+                          multicast specified whether or not the multicast configuration was migrated.
+                          DEPRECATED: network type migration is no longer supported.
                         type: boolean
                     type: object
                   mode:
-                    description: mode indicates the mode of network migration. The
-                      supported values are "Live", "Offline" and omitted. A "Live"
-                      migration operation will not cause service interruption by migrating
-                      the CNI of each node one by one. The cluster network will work
-                      as normal during the network migration. An "Offline" migration
-                      operation will cause service interruption. During an "Offline"
-                      migration, two rounds of node reboots are required. The cluster
-                      network will be malfunctioning during the network migration.
-                      When omitted, this means no opinion and the platform is left
-                      to choose a reasonable default which is subject to change over
-                      time. The current default value is "Offline".
+                    description: |-
+                      mode indicates the mode of network type migration.
+                      DEPRECATED: network type migration is no longer supported, and setting
+                      this to a non-empty value will result in the network operator rejecting
+                      the configuration.
                     enum:
                     - Live
                     - Offline
                     - ""
                     type: string
                   mtu:
-                    description: mtu contains the MTU migration configuration. Set
-                      this to allow changing the MTU values for the default network.
-                      If unset, the operation of changing the MTU for the default
-                      network will be rejected.
+                    description: |-
+                      mtu contains the MTU migration configuration. Set this to allow changing
+                      the MTU values for the default network. If unset, the operation of
+                      changing the MTU for the default network will be rejected.
                     properties:
                       machine:
-                        description: machine contains MTU migration configuration
-                          for the machine's uplink. Needs to be migrated along with
-                          the default network MTU unless the current uplink MTU already
-                          accommodates the default network MTU.
+                        description: |-
+                          machine contains MTU migration configuration for the machine's uplink.
+                          Needs to be migrated along with the default network MTU unless the
+                          current uplink MTU already accommodates the default network MTU.
                         properties:
                           from:
                             description: from is the MTU to migrate from.
@@ -802,10 +830,10 @@ spec:
                             type: integer
                         type: object
                       network:
-                        description: network contains information about MTU migration
-                          for the default network. Migrations are only allowed to
-                          MTU values lower than the machine's uplink MTU by the minimum
-                          appropriate offset.
+                        description: |-
+                          network contains information about MTU migration for the default network.
+                          Migrations are only allowed to MTU values lower than the machine's uplink
+                          MTU by the minimum appropriate offset.
                         properties:
                           from:
                             description: from is the MTU to migrate from.
@@ -820,27 +848,33 @@ spec:
                         type: object
                     type: object
                   networkType:
-                    description: networkType is the target type of network migration.
-                      Set this to the target network type to allow changing the default
-                      network. If unset, the operation of changing cluster default
-                      network plugin will be rejected. The supported values are OpenShiftSDN,
-                      OVNKubernetes
+                    description: |-
+                      networkType was previously used when changing the default network type.
+                      DEPRECATED: network type migration is no longer supported, and setting
+                      this to a non-empty value will result in the network operator rejecting
+                      the configuration.
                     type: string
                 type: object
+                x-kubernetes-validations:
+                - message: networkType migration in mode other than 'Live' may not
+                    be configured at the same time as mtu migration
+                  rule: '!has(self.mtu) || !has(self.networkType) || self.networkType
+                    == "" || has(self.mode) && self.mode == ''Live'''
               observedConfig:
-                description: observedConfig holds a sparse config that controller
-                  has observed from the cluster state.  It exists in spec because
+                description: |-
+                  observedConfig holds a sparse config that controller has observed from the cluster state.  It exists in spec because
                   it is an input to the level for the operator
                 nullable: true
                 type: object
                 x-kubernetes-preserve-unknown-fields: true
               operatorLogLevel:
                 default: Normal
-                description: "operatorLogLevel is an intent based logging for the
-                  operator itself.  It does not give fine grained control, but it
-                  is a simple way to manage coarse grained logging choices that operators
-                  have to interpret for themselves. \n Valid values are: \"Normal\",
-                  \"Debug\", \"Trace\", \"TraceAll\". Defaults to \"Normal\"."
+                description: |-
+                  operatorLogLevel is an intent based logging for the operator itself.  It does not give fine grained control, but it is a
+                  simple way to manage coarse grained logging choices that operators have to interpret for themselves.
+
+                  Valid values are: "Normal", "Debug", "Trace", "TraceAll".
+                  Defaults to "Normal".
                 enum:
                 - ""
                 - Normal
@@ -849,44 +883,37 @@ spec:
                 - TraceAll
                 type: string
               serviceNetwork:
-                description: serviceNetwork is the ip address pool to use for Service
-                  IPs Currently, all existing network providers only support a single
-                  value here, but this is an array to allow for growth.
+                description: |-
+                  serviceNetwork is the ip address pool to use for Service IPs
+                  Currently, all existing network providers only support a single value
+                  here, but this is an array to allow for growth.
                 items:
                   type: string
                 type: array
                 x-kubernetes-list-type: atomic
               unsupportedConfigOverrides:
-                description: unsupportedConfigOverrides overrides the final configuration
-                  that was computed by the operator. Red Hat does not support the
-                  use of this field. Misuse of this field could lead to unexpected
-                  behavior or conflict with other configuration options. Seek guidance
-                  from the Red Hat support before using this field. Use of this property
-                  blocks cluster upgrades, it must be removed before upgrading your
-                  cluster.
+                description: |-
+                  unsupportedConfigOverrides overrides the final configuration that was computed by the operator.
+                  Red Hat does not support the use of this field.
+                  Misuse of this field could lead to unexpected behavior or conflict with other configuration options.
+                  Seek guidance from the Red Hat support before using this field.
+                  Use of this property blocks cluster upgrades, it must be removed before upgrading your cluster.
                 nullable: true
                 type: object
                 x-kubernetes-preserve-unknown-fields: true
               useMultiNetworkPolicy:
-                description: useMultiNetworkPolicy enables a controller which allows
-                  for MultiNetworkPolicy objects to be used on additional networks
-                  as created by Multus CNI. MultiNetworkPolicy are similar to NetworkPolicy
+                description: |-
+                  useMultiNetworkPolicy enables a controller which allows for
+                  MultiNetworkPolicy objects to be used on additional networks as
+                  created by Multus CNI. MultiNetworkPolicy are similar to NetworkPolicy
                   objects, but NetworkPolicy objects only apply to the primary interface.
-                  With MultiNetworkPolicy, you can control the traffic that a pod
-                  can receive over the secondary interfaces. If unset, this property
-                  defaults to 'false' and MultiNetworkPolicy objects are ignored.
-                  If 'disableMultiNetwork' is 'true' then the value of this field
-                  is ignored.
+                  With MultiNetworkPolicy, you can control the traffic that a pod can receive
+                  over the secondary interfaces. If unset, this property defaults to 'false'
+                  and MultiNetworkPolicy objects are ignored. If 'disableMultiNetwork' is
+                  'true' then the value of this field is ignored.
                 type: boolean
             type: object
             x-kubernetes-validations:
-            - message: Route advertisements cannot be Enabled if 'FRR' routing capability
-                provider is not available
-              rule: (has(self.additionalRoutingCapabilities) && ('FRR' in self.additionalRoutingCapabilities.providers))
-                || !has(self.defaultNetwork) || !has(self.defaultNetwork.ovnKubernetesConfig)
-                || !has(self.defaultNetwork.ovnKubernetesConfig.routeAdvertisements)
-                || self.defaultNetwork.ovnKubernetesConfig.routeAdvertisements !=
-                'Enabled'
             - message: invalid value for IPForwarding, valid values are 'Restricted'
                 or 'Global'
               rule: '!has(self.defaultNetwork) || !has(self.defaultNetwork.ovnKubernetesConfig)
@@ -897,8 +924,16 @@ spec:
                 || self.defaultNetwork.ovnKubernetesConfig.gatewayConfig.ipForwarding
                 == ''Restricted'' || self.defaultNetwork.ovnKubernetesConfig.gatewayConfig.ipForwarding
                 == ''Global'''
+            - message: Route advertisements cannot be Enabled if 'FRR' routing capability
+                provider is not available
+              rule: (has(self.additionalRoutingCapabilities) && ('FRR' in self.additionalRoutingCapabilities.providers))
+                || !has(self.defaultNetwork) || !has(self.defaultNetwork.ovnKubernetesConfig)
+                || !has(self.defaultNetwork.ovnKubernetesConfig.routeAdvertisements)
+                || self.defaultNetwork.ovnKubernetesConfig.routeAdvertisements !=
+                'Enabled'
           status:
-            description: NetworkStatus is detailed operator status, which is distilled
+            description: |-
+              NetworkStatus is detailed operator status, which is distilled
               up to the Network clusteroperator object.
             properties:
               conditions:
@@ -907,6 +942,9 @@ spec:
                   description: OperatorCondition is just the standard condition fields.
                   properties:
                     lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
                       format: date-time
                       type: string
                     message:
@@ -914,10 +952,20 @@ spec:
                     reason:
                       type: string
                     status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
                       type: string
                     type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                       type: string
                   required:
+                  - lastTransitionTime
+                  - status
                   - type
                   type: object
                 type: array
@@ -954,9 +1002,27 @@ spec:
                       description: resource is the resource type of the thing you're
                         tracking
                       type: string
+                  required:
+                  - group
+                  - name
+                  - namespace
+                  - resource
                   type: object
                 type: array
-                x-kubernetes-list-type: atomic
+                x-kubernetes-list-map-keys:
+                - group
+                - resource
+                - namespace
+                - name
+                x-kubernetes-list-type: map
+              latestAvailableRevision:
+                description: latestAvailableRevision is the deploymentID of the most
+                  recent deployment
+                format: int32
+                type: integer
+                x-kubernetes-validations:
+                - message: must only increase
+                  rule: self >= oldSelf
               observedGeneration:
                 description: observedGeneration is the last generation change you've
                   dealt with
@@ -974,3 +1040,5 @@ spec:
         type: object
     served: true
     storage: true
+    subresources:
+      status: {}


### PR DESCRIPTION
- **Fix networks.yaml refers to routeAdvertisements that's not there**
- **Fix outdated envtest setup**
- **Cancel k8sManager properly in AfterSuite**

Fixes https://github.com/metallb/metallb-operator/issues/535

<!-- Thanks for sending a pull request!
1. If this is your first time, please read the [contributing guide](https://metallb.universe.tf/community/#contributing)
2. For non-trivial pull requests, please [file an
   issue](https://github.com/metallb/metallb-operator/issues/new) first, and get
   agreement that the change is a good idea, and a general guideline
   for how it should be implemented, before sending code. Large PRs
   that weren't first discussed and agreed upon in an issue won't be
   accepted.
3. If the PR fixes a particular bug, please include the words "Fixed
   #<issue number>" in the PR text, so that the bug auto-closes when
   the PR is merged.
-->

**Is this a BUG FIX or a FEATURE ?**:

/kind bug

> Uncomment only one, leave it on its own line:
>
> /kind bug
> /kind cleanup
> /kind feature
> /kind design
> /kind flake
> /kind failing
> /kind documentation
> /kind regression

**What this PR does / why we need it**:

**Special notes for your reviewer**:

- The testenv setup script was removed from google's repositories. There's a "new" way to set up test env, refer e.g. to the frr-k8s' Makefile for that --> switch to the new way of setting up testenv
- After bumping the testenv version, it started complaining (rightfully so) about an issue in the networks.yaml - the CEL rules referred to routeAdvertisements which was not defined in the yaml. Therefore, I bumped networks.yaml to the latest definition from openshift/api
- After bumping the testenv version, we need to properly cancel k8sManager in the AfterSuite (see upstream bug in commit message) and cf. other projects such as frr-k8s

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note

```
