### PR TITLE
Fix OCP ServiceMonitor rejection due to filesystem access

### DIFF
--- a/pkg/helm/config.go
+++ b/pkg/helm/config.go
@@ -60,10 +60,15 @@ func setOcpMonitorFields(obj *unstructured.Unstructured) error {
 		return err
 	}
 	for _, ep := range eps {
-		err := unstructured.SetNestedField(ep.(map[string]interface{}), false, "tlsConfig", "insecureSkipVerify")
+		epMap := ep.(map[string]interface{})
+		err := unstructured.SetNestedField(epMap, false, "tlsConfig", "insecureSkipVerify")
 		if err != nil {
 			return err
 		}
+		unstructured.RemoveNestedField(epMap, "bearerTokenFile")
+		unstructured.RemoveNestedField(epMap, "tlsConfig", "caFile")
+		unstructured.RemoveNestedField(epMap, "tlsConfig", "certFile")
+		unstructured.RemoveNestedField(epMap, "tlsConfig", "keyFile")
 	}
 	err = unstructured.SetNestedSlice(obj.Object, eps, "spec", "endpoints")
 	if err != nil {
@@ -107,12 +112,25 @@ func ocpServingCertAnnotationFor(secretName string) map[string]interface{} {
 	}
 }
 
-func ocpServiceMonitorTLSConfig(component, namespace string) map[string]interface{} {
+func ocpServiceMonitorTLSConfig(component, namespace, certSecret string) map[string]interface{} {
 	return map[string]interface{}{
-		"caFile":             "/etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt",
+		"ca": map[string]interface{}{
+			"configMap": map[string]interface{}{
+				"name": "openshift-service-ca.crt",
+				"key":  "service-ca.crt",
+			},
+		},
+		"cert": map[string]interface{}{
+			"secret": map[string]interface{}{
+				"name": certSecret,
+				"key":  "tls.crt",
+			},
+		},
+		"keySecret": map[string]interface{}{
+			"name": certSecret,
+			"key":  "tls.key",
+		},
 		"serverName":         fmt.Sprintf("%s-monitor-service.%s.svc", component, namespace),
-		"certFile":           "/etc/prometheus/secrets/metrics-client-certs/tls.crt",
-		"keyFile":            "/etc/prometheus/secrets/metrics-client-certs/tls.key",
 		"insecureSkipVerify": false,
 	}
 }

--- a/pkg/helm/frrk8s.go
+++ b/pkg/helm/frrk8s.go
@@ -221,7 +221,7 @@ func prometheusValues(envConfig params.EnvConfig) map[string]interface{} {
 	annotations := map[string]interface{}{}
 
 	if envConfig.IsOpenshift {
-		tlsConfig = ocpServiceMonitorTLSConfig("frr-k8s", envConfig.Namespace)
+		tlsConfig = ocpServiceMonitorTLSConfig("frr-k8s", envConfig.Namespace, frrk8sCertsSecret)
 		annotations = ocpServingCertAnnotationFor(frrk8sCertsSecret)
 	}
 

--- a/pkg/helm/metallb.go
+++ b/pkg/helm/metallb.go
@@ -223,8 +223,8 @@ func metalLBprometheusValues(envConfig params.EnvConfig) map[string]interface{} 
 	controllerAnnotations := map[string]interface{}{}
 
 	if envConfig.IsOpenshift {
-		speakerTLSConfig = ocpServiceMonitorTLSConfig("speaker", envConfig.Namespace)
-		controllerTLSConfig = ocpServiceMonitorTLSConfig("controller", envConfig.Namespace)
+		speakerTLSConfig = ocpServiceMonitorTLSConfig("speaker", envConfig.Namespace, speakerCertsSecret)
+		controllerTLSConfig = ocpServiceMonitorTLSConfig("controller", envConfig.Namespace, controllerCertsSecret)
 		speakerAnnotations = ocpServingCertAnnotationFor(speakerCertsSecret)
 		controllerAnnotations = ocpServingCertAnnotationFor(controllerCertsSecret)
 	}

--- a/pkg/helm/testdata/ocp-metrics-controller-monitor.golden
+++ b/pkg/helm/testdata/ocp-metrics-controller-monitor.golden
@@ -17,15 +17,27 @@
     "spec": {
         "endpoints": [
             {
-                "bearerTokenFile": "/var/run/secrets/kubernetes.io/serviceaccount/token",
                 "honorLabels": true,
                 "port": "metricshttps",
                 "scheme": "https",
                 "tlsConfig": {
-                    "caFile": "/etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt",
-                    "certFile": "/etc/prometheus/secrets/metrics-client-certs/tls.crt",
+                    "ca": {
+                        "configMap": {
+                            "key": "service-ca.crt",
+                            "name": "openshift-service-ca.crt"
+                        }
+                    },
+                    "cert": {
+                        "secret": {
+                            "key": "tls.crt",
+                            "name": "controller-certs-secret"
+                        }
+                    },
                     "insecureSkipVerify": false,
-                    "keyFile": "/etc/prometheus/secrets/metrics-client-certs/tls.key",
+                    "keySecret": {
+                        "key": "tls.key",
+                        "name": "controller-certs-secret"
+                    },
                     "serverName": "controller-monitor-service.metallb-test-namespace.svc"
                 }
             }

--- a/pkg/helm/testdata/ocp-metrics-frr-k8s-monitor.golden
+++ b/pkg/helm/testdata/ocp-metrics-frr-k8s-monitor.golden
@@ -18,7 +18,6 @@
     "spec": {
         "endpoints": [
             {
-                "bearerTokenFile": "/var/run/secrets/kubernetes.io/serviceaccount/token",
                 "honorLabels": true,
                 "metricRelabelings": [
                     {
@@ -41,15 +40,27 @@
                 "port": "metricshttps",
                 "scheme": "https",
                 "tlsConfig": {
-                    "caFile": "/etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt",
-                    "certFile": "/etc/prometheus/secrets/metrics-client-certs/tls.crt",
+                    "ca": {
+                        "configMap": {
+                            "key": "service-ca.crt",
+                            "name": "openshift-service-ca.crt"
+                        }
+                    },
+                    "cert": {
+                        "secret": {
+                            "key": "tls.crt",
+                            "name": "frr-k8s-certs-secret"
+                        }
+                    },
                     "insecureSkipVerify": false,
-                    "keyFile": "/etc/prometheus/secrets/metrics-client-certs/tls.key",
+                    "keySecret": {
+                        "key": "tls.key",
+                        "name": "frr-k8s-certs-secret"
+                    },
                     "serverName": "frr-k8s-monitor-service.metallb-test-namespace.svc"
                 }
             },
             {
-                "bearerTokenFile": "/var/run/secrets/kubernetes.io/serviceaccount/token",
                 "honorLabels": true,
                 "metricRelabelings": [
                     {
@@ -72,10 +83,23 @@
                 "port": "frrmetricshttps",
                 "scheme": "https",
                 "tlsConfig": {
-                    "caFile": "/etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt",
-                    "certFile": "/etc/prometheus/secrets/metrics-client-certs/tls.crt",
+                    "ca": {
+                        "configMap": {
+                            "key": "service-ca.crt",
+                            "name": "openshift-service-ca.crt"
+                        }
+                    },
+                    "cert": {
+                        "secret": {
+                            "key": "tls.crt",
+                            "name": "frr-k8s-certs-secret"
+                        }
+                    },
                     "insecureSkipVerify": false,
-                    "keyFile": "/etc/prometheus/secrets/metrics-client-certs/tls.key",
+                    "keySecret": {
+                        "key": "tls.key",
+                        "name": "frr-k8s-certs-secret"
+                    },
                     "serverName": "frr-k8s-monitor-service.metallb-test-namespace.svc"
                 }
             }

--- a/pkg/helm/testdata/ocp-metrics-speaker-monitor.golden
+++ b/pkg/helm/testdata/ocp-metrics-speaker-monitor.golden
@@ -18,28 +18,52 @@
     "spec": {
         "endpoints": [
             {
-                "bearerTokenFile": "/var/run/secrets/kubernetes.io/serviceaccount/token",
                 "honorLabels": true,
                 "port": "metricshttps",
                 "scheme": "https",
                 "tlsConfig": {
-                    "caFile": "/etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt",
-                    "certFile": "/etc/prometheus/secrets/metrics-client-certs/tls.crt",
+                    "ca": {
+                        "configMap": {
+                            "key": "service-ca.crt",
+                            "name": "openshift-service-ca.crt"
+                        }
+                    },
+                    "cert": {
+                        "secret": {
+                            "key": "tls.crt",
+                            "name": "speaker-certs-secret"
+                        }
+                    },
                     "insecureSkipVerify": false,
-                    "keyFile": "/etc/prometheus/secrets/metrics-client-certs/tls.key",
+                    "keySecret": {
+                        "key": "tls.key",
+                        "name": "speaker-certs-secret"
+                    },
                     "serverName": "speaker-monitor-service.metallb-test-namespace.svc"
                 }
             },
             {
-                "bearerTokenFile": "/var/run/secrets/kubernetes.io/serviceaccount/token",
                 "honorLabels": true,
                 "port": "frrmetricshttps",
                 "scheme": "https",
                 "tlsConfig": {
-                    "caFile": "/etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt",
-                    "certFile": "/etc/prometheus/secrets/metrics-client-certs/tls.crt",
+                    "ca": {
+                        "configMap": {
+                            "key": "service-ca.crt",
+                            "name": "openshift-service-ca.crt"
+                        }
+                    },
+                    "cert": {
+                        "secret": {
+                            "key": "tls.crt",
+                            "name": "speaker-certs-secret"
+                        }
+                    },
                     "insecureSkipVerify": false,
-                    "keyFile": "/etc/prometheus/secrets/metrics-client-certs/tls.key",
+                    "keySecret": {
+                        "key": "tls.key",
+                        "name": "speaker-certs-secret"
+                    },
                     "serverName": "speaker-monitor-service.metallb-test-namespace.svc"
                 }
             }


### PR DESCRIPTION
## Summary

OpenShift's user-workload Prometheus sets `arbitraryFSAccessThroughSMs` to deny, which causes the Prometheus Operator to reject all MetalLB ServiceMonitors (`speaker-monitor`, `controller-monitor`, `frr-k8s-monitor`) that reference local file paths via `bearerTokenFile` or `tlsConfig` file fields (`caFile`, `certFile`, `keyFile`). This triggers the `PrometheusOperatorRejectedResources` alert and prevents metrics collection under user-workload monitoring.

## Changes

- **`pkg/helm/config.go` – `ocpServiceMonitorTLSConfig()`**: Replace file-based `tlsConfig` paths with secret/configmap references pointing to existing resources in `metallb-system`:
  - `ca.configMap` → `openshift-service-ca.crt` (injected by OpenShift service-ca controller)
  - `cert.secret` → `{component}-certs-secret` (created by serving cert signer)
  - `keySecret` → `{component}-certs-secret`

- **`pkg/helm/config.go` – `setOcpMonitorFields()`**: Strip `bearerTokenFile` and all residual file-based `tlsConfig` fields (`caFile`, `certFile`, `keyFile`) from every ServiceMonitor endpoint during OCP post-processing.

- **Golden test files**: Updated all three OCP ServiceMonitor test fixtures.

## Before (rejected by Prometheus Operator)

```yaml
spec:
  endpoints:
  - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
    tlsConfig:
      caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
      certFile: /etc/prometheus/secrets/metrics-client-certs/tls.crt
      keyFile: /etc/prometheus/secrets/metrics-client-certs/tls.key
```

## After (accepted by Prometheus Operator)

```yaml
spec:
  endpoints:
  - tlsConfig:
      ca:
        configMap:
          name: openshift-service-ca.crt
          key: service-ca.crt
      cert:
        secret:
          name: speaker-certs-secret
          key: tls.crt
      keySecret:
        name: speaker-certs-secret
        key: tls.key
```

## Impact

- Only affects OpenShift deployments (`IsOpenshift == true`); vanilla Kubernetes is untouched
- MetalLB load balancing is unaffected
- Metrics via platform Prometheus (with `cluster-monitoring=true` label) continue to work
- Metrics via user-workload Prometheus (without the label) start working after this fix

## Precedent

Other OpenShift operators have made the same change:
- [openshift/cluster-monitoring-operator#1392](https://github.com/openshift/cluster-monitoring-operator/pull/1392) – Replace bearer token by client TLS certificate
- [openshift/cluster-kube-apiserver-operator#1930](https://github.com/openshift/cluster-kube-apiserver-operator/pull/1930) – Remove bearerTokenFile and file-based TLS from ServiceMonitors
- [operator-framework/operator-sdk#7003](https://github.com/operator-framework/operator-sdk/issues/7003) – Same issue reported for scaffolded operators

## Verification

- Bug confirmed on OCP 4.20.22, 4.21.3, and 4.22.0-rc.4
- Fix tested on OCP 4.20.22 and 4.21.3 – `PrometheusOperatorRejectedResources` alert resolved
- All 9 unit tests in `pkg/helm` pass

## Jira

Fixes: https://redhat.atlassian.net/browse/OCPBUGS-86703


Made with [Cursor](https://cursor.com)