### PR TITLE
Replace deprecated patchesStrategicMerge with patches

### DIFF
--- a/config/frr-webhook-prometheus/kustomization.yaml
+++ b/config/frr-webhook-prometheus/kustomization.yaml
@@ -1,9 +1,9 @@
 
-patchesStrategicMerge:
-- bgpTypeFRR.yaml
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- ../default
-- prometheus_sa.yaml
+  - ../default
+  - prometheus_sa.yaml
 namespace: metallb-system
+patches:
+  - path: bgpTypeFRR.yaml

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -1,10 +1,10 @@
-resources:
-  - manager.yaml
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-patchesStrategicMerge:
-  - env.yaml
+resources:
+  - manager.yaml
 images:
   - name: controller
     newName: quay.io/metallb/metallb-operator
     newTag: main
+patches:
+  - path: env.yaml

--- a/config/manifests/kustomization.yaml
+++ b/config/manifests/kustomization.yaml
@@ -1,11 +1,12 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
 # These resources constitute the fully configured set of manifests
 # used to generate the 'manifests/' directory in a bundle.
 resources:
-- bases/metallb-operator.clusterserviceversion.yaml
-- ../default
-- ../metallb_rbac
-- ../samples
-- ../scorecard
-
-patchesStrategicMerge:
-  - disable-cert-rotation.yaml
+  - bases/metallb-operator.clusterserviceversion.yaml
+  - ../default
+  - ../metallb_rbac
+  - ../samples
+  - ../scorecard
+patches:
+  - path: disable-cert-rotation.yaml

--- a/config/webhook/kustomization.yaml
+++ b/config/webhook/kustomization.yaml
@@ -1,10 +1,12 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
 # These resources constitute the fully configured set of manifests
 # used to generate the 'manifests/' directory in a bundle.
 resources:
-- ./webhook
-- ./backend
-- manifests.yaml
-- secret.yaml
-- operator-service.yaml
-patchesStrategicMerge:
-- service.yaml
+  - ./webhook
+  - ./backend
+  - manifests.yaml
+  - secret.yaml
+  - operator-service.yaml
+patches:
+  - path: service.yaml

--- a/hack/ocp-kustomize-overlay/kustomization.yaml
+++ b/hack/ocp-kustomize-overlay/kustomization.yaml
@@ -4,12 +4,12 @@ resources:
   - ../../_cache/metallb/config/frr
   - rbac.yaml
 
-patchesStrategicMerge:
-  - controller-webhook-patch.yaml
-  - webhookcainjection-patch.yaml
-  - crd-conversion-patch.yaml
-  - crdcainjection-patch.yaml
-  - webhookservicecainjection_patch.yaml
-  - permission-patch.yaml
 
 namespace: metallb-system
+patches:
+  - path: controller-webhook-patch.yaml
+  - path: webhookcainjection-patch.yaml
+  - path: crd-conversion-patch.yaml
+  - path: crdcainjection-patch.yaml
+  - path: webhookservicecainjection_patch.yaml
+  - path: permission-patch.yaml


### PR DESCRIPTION
The patchesStrategicMerge field was deprecated in kustomize v5.0.0 in favor of the patches field. Migrate all kustomization.yaml files to use the new syntax, and add missing apiVersion and kind fields where needed.

**Is this a BUG FIX or a FEATURE ?**:

/kind cleanup

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
fixes #355