### PR TITLE
Disable metrics server by default

### DIFF
--- a/main.go
+++ b/main.go
@@ -94,7 +94,7 @@ var build = "develop"
 
 func main() {
 	var (
-		metricsAddr          = flag.String("metrics-addr", ":0", "The address the metric endpoint binds to.")
+		metricsAddr          = flag.String("metrics-addr", "0", "The address the metric endpoint binds to.")
 		enableLeaderElection = flag.Bool("enable-leader-election", false, "Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
 		disableCertRotation   = flag.Bool("disable-cert-rotation", false, "disable automatic generation and rotation of webhook TLS certificates/keys")


### PR DESCRIPTION
The default metrics bind address :0 causes the OS to assign a random ephemeral port on each pod restart, making the metrics endpoint undiscoverable. Change the default to 0 to disable the metrics server entirely. Users can still opt in via --metrics-addr=:PORT.

**Is this a BUG FIX or a FEATURE ?**:

/kind bug

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```

fixes #508