### PR TITLE
Revert "Fix OCP ServiceMonitor rejection due to filesystem access"

### DIFF
--- a/pkg/helm/config.go
+++ b/pkg/helm/config.go
@@ -60,15 +60,10 @@ func setOcpMonitorFields(obj *unstructured.Unstructured) error {
 		return err
 	}
 	for _, ep := range eps {
-		epMap := ep.(map[string]interface{})
-		err := unstructured.SetNestedField(epMap, false, "tlsConfig", "insecureSkipVerify")
+		err := unstructured.SetNestedField(ep.(map[string]interface{}), false, "tlsConfig", "insecureSkipVerify")
 		if err != nil {
 			return err
 		}
-		unstructured.RemoveNestedField(epMap, "bearerTokenFile")
-		unstructured.RemoveNestedField(epMap, "tlsConfig", "caFile")
-		unstructured.RemoveNestedField(epMap, "tlsConfig", "certFile")
-		unstructured.RemoveNestedField(epMap, "tlsConfig", "keyFile")
 	}
 	err = unstructured.SetNestedSlice(obj.Object, eps, "spec", "endpoints")
 	if err != nil {
@@ -112,25 +107,12 @@ func ocpServingCertAnnotationFor(secretName string) map[string]interface{} {
 	}
 }
 
-func ocpServiceMonitorTLSConfig(component, namespace, certSecret string) map[string]interface{} {
+func ocpServiceMonitorTLSConfig(component, namespace string) map[string]interface{} {
 	return map[string]interface{}{
-		"ca": map[string]interface{}{
-			"configMap": map[string]interface{}{
-				"name": "openshift-service-ca.crt",
-				"key":  "service-ca.crt",
-			},
-		},
-		"cert": map[string]interface{}{
-			"secret": map[string]interface{}{
-				"name": certSecret,
-				"key":  "tls.crt",
-			},
-		},
-		"keySecret": map[string]interface{}{
-			"name": certSecret,
-			"key":  "tls.key",
-		},
+		"caFile":             "/etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt",
 		"serverName":         fmt.Sprintf("%s-monitor-service.%s.svc", component, namespace),
+		"certFile":           "/etc/prometheus/secrets/metrics-client-certs/tls.crt",
+		"keyFile":            "/etc/prometheus/secrets/metrics-client-certs/tls.key",
 		"insecureSkipVerify": false,
 	}
 }

--- a/pkg/helm/frrk8s.go
+++ b/pkg/helm/frrk8s.go
@@ -221,7 +221,7 @@ func prometheusValues(envConfig params.EnvConfig) map[string]interface{} {
 	annotations := map[string]interface{}{}
 
 	if envConfig.IsOpenshift {
-		tlsConfig = ocpServiceMonitorTLSConfig("frr-k8s", envConfig.Namespace, frrk8sCertsSecret)
+		tlsConfig = ocpServiceMonitorTLSConfig("frr-k8s", envConfig.Namespace)
 		annotations = ocpServingCertAnnotationFor(frrk8sCertsSecret)
 	}
 

--- a/pkg/helm/metallb.go
+++ b/pkg/helm/metallb.go
@@ -223,8 +223,8 @@ func metalLBprometheusValues(envConfig params.EnvConfig) map[string]interface{} 
 	controllerAnnotations := map[string]interface{}{}
 
 	if envConfig.IsOpenshift {
-		speakerTLSConfig = ocpServiceMonitorTLSConfig("speaker", envConfig.Namespace, speakerCertsSecret)
-		controllerTLSConfig = ocpServiceMonitorTLSConfig("controller", envConfig.Namespace, controllerCertsSecret)
+		speakerTLSConfig = ocpServiceMonitorTLSConfig("speaker", envConfig.Namespace)
+		controllerTLSConfig = ocpServiceMonitorTLSConfig("controller", envConfig.Namespace)
 		speakerAnnotations = ocpServingCertAnnotationFor(speakerCertsSecret)
 		controllerAnnotations = ocpServingCertAnnotationFor(controllerCertsSecret)
 	}

--- a/pkg/helm/testdata/ocp-metrics-controller-monitor.golden
+++ b/pkg/helm/testdata/ocp-metrics-controller-monitor.golden
@@ -17,27 +17,15 @@
     "spec": {
         "endpoints": [
             {
+                "bearerTokenFile": "/var/run/secrets/kubernetes.io/serviceaccount/token",
                 "honorLabels": true,
                 "port": "metricshttps",
                 "scheme": "https",
                 "tlsConfig": {
-                    "ca": {
-                        "configMap": {
-                            "key": "service-ca.crt",
-                            "name": "openshift-service-ca.crt"
-                        }
-                    },
-                    "cert": {
-                        "secret": {
-                            "key": "tls.crt",
-                            "name": "controller-certs-secret"
-                        }
-                    },
+                    "caFile": "/etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt",
+                    "certFile": "/etc/prometheus/secrets/metrics-client-certs/tls.crt",
                     "insecureSkipVerify": false,
-                    "keySecret": {
-                        "key": "tls.key",
-                        "name": "controller-certs-secret"
-                    },
+                    "keyFile": "/etc/prometheus/secrets/metrics-client-certs/tls.key",
                     "serverName": "controller-monitor-service.metallb-test-namespace.svc"
                 }
             }

--- a/pkg/helm/testdata/ocp-metrics-frr-k8s-monitor.golden
+++ b/pkg/helm/testdata/ocp-metrics-frr-k8s-monitor.golden
@@ -18,6 +18,7 @@
     "spec": {
         "endpoints": [
             {
+                "bearerTokenFile": "/var/run/secrets/kubernetes.io/serviceaccount/token",
                 "honorLabels": true,
                 "metricRelabelings": [
                     {
@@ -40,27 +41,15 @@
                 "port": "metricshttps",
                 "scheme": "https",
                 "tlsConfig": {
-                    "ca": {
-                        "configMap": {
-                            "key": "service-ca.crt",
-                            "name": "openshift-service-ca.crt"
-                        }
-                    },
-                    "cert": {
-                        "secret": {
-                            "key": "tls.crt",
-                            "name": "frr-k8s-certs-secret"
-                        }
-                    },
+                    "caFile": "/etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt",
+                    "certFile": "/etc/prometheus/secrets/metrics-client-certs/tls.crt",
                     "insecureSkipVerify": false,
-                    "keySecret": {
-                        "key": "tls.key",
-                        "name": "frr-k8s-certs-secret"
-                    },
+                    "keyFile": "/etc/prometheus/secrets/metrics-client-certs/tls.key",
                     "serverName": "frr-k8s-monitor-service.metallb-test-namespace.svc"
                 }
             },
             {
+                "bearerTokenFile": "/var/run/secrets/kubernetes.io/serviceaccount/token",
                 "honorLabels": true,
                 "metricRelabelings": [
                     {
@@ -83,23 +72,10 @@
                 "port": "frrmetricshttps",
                 "scheme": "https",
                 "tlsConfig": {
-                    "ca": {
-                        "configMap": {
-                            "key": "service-ca.crt",
-                            "name": "openshift-service-ca.crt"
-                        }
-                    },
-                    "cert": {
-                        "secret": {
-                            "key": "tls.crt",
-                            "name": "frr-k8s-certs-secret"
-                        }
-                    },
+                    "caFile": "/etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt",
+                    "certFile": "/etc/prometheus/secrets/metrics-client-certs/tls.crt",
                     "insecureSkipVerify": false,
-                    "keySecret": {
-                        "key": "tls.key",
-                        "name": "frr-k8s-certs-secret"
-                    },
+                    "keyFile": "/etc/prometheus/secrets/metrics-client-certs/tls.key",
                     "serverName": "frr-k8s-monitor-service.metallb-test-namespace.svc"
                 }
             }

--- a/pkg/helm/testdata/ocp-metrics-speaker-monitor.golden
+++ b/pkg/helm/testdata/ocp-metrics-speaker-monitor.golden
@@ -18,52 +18,28 @@
     "spec": {
         "endpoints": [
             {
+                "bearerTokenFile": "/var/run/secrets/kubernetes.io/serviceaccount/token",
                 "honorLabels": true,
                 "port": "metricshttps",
                 "scheme": "https",
                 "tlsConfig": {
-                    "ca": {
-                        "configMap": {
-                            "key": "service-ca.crt",
-                            "name": "openshift-service-ca.crt"
-                        }
-                    },
-                    "cert": {
-                        "secret": {
-                            "key": "tls.crt",
-                            "name": "speaker-certs-secret"
-                        }
-                    },
+                    "caFile": "/etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt",
+                    "certFile": "/etc/prometheus/secrets/metrics-client-certs/tls.crt",
                     "insecureSkipVerify": false,
-                    "keySecret": {
-                        "key": "tls.key",
-                        "name": "speaker-certs-secret"
-                    },
+                    "keyFile": "/etc/prometheus/secrets/metrics-client-certs/tls.key",
                     "serverName": "speaker-monitor-service.metallb-test-namespace.svc"
                 }
             },
             {
+                "bearerTokenFile": "/var/run/secrets/kubernetes.io/serviceaccount/token",
                 "honorLabels": true,
                 "port": "frrmetricshttps",
                 "scheme": "https",
                 "tlsConfig": {
-                    "ca": {
-                        "configMap": {
-                            "key": "service-ca.crt",
-                            "name": "openshift-service-ca.crt"
-                        }
-                    },
-                    "cert": {
-                        "secret": {
-                            "key": "tls.crt",
-                            "name": "speaker-certs-secret"
-                        }
-                    },
+                    "caFile": "/etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt",
+                    "certFile": "/etc/prometheus/secrets/metrics-client-certs/tls.crt",
                     "insecureSkipVerify": false,
-                    "keySecret": {
-                        "key": "tls.key",
-                        "name": "speaker-certs-secret"
-                    },
+                    "keyFile": "/etc/prometheus/secrets/metrics-client-certs/tls.key",
                     "serverName": "speaker-monitor-service.metallb-test-namespace.svc"
                 }
             }


### PR DESCRIPTION
This reverts commit 213ede162299b32b520eecfd680f9509a523ee0f.

MetalLB is a platform component, and this broke metrics for everyone using it as one.
Reverting the PR and we should consider wether to move to a non-deprecated method for the bearerToken (currently there is no standard approach).

<!-- Thanks for sending a pull request!
1. If this is your first time, please read the [contributing guide](https://metallb.universe.tf/community/#contributing)
2. For non-trivial pull requests, please [file an
   issue](https://github.com/metallb/metallb-operator/issues/new) first, and get
   agreement that the change is a good idea, and a general guideline
   for how it should be implemented, before sending code. Large PRs
   that weren't first discussed and agreed upon in an issue won't be
   accepted.
3. If the PR fixes a particular bug, please include the words "Fixed
   #<issue number>" in the PR text, so that the bug auto-closes when
   the PR is merged.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
/kind bug
> /kind cleanup
> /kind feature
> /kind design
> /kind flake
> /kind failing
> /kind documentation
> /kind regression

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
