### PR TITLE
Add custom metallb-speaker SCC for OCP speaker pods

### DIFF
--- a/bin/metallb-operator.yaml
+++ b/bin/metallb-operator.yaml
@@ -4886,6 +4886,15 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - security.openshift.io
+  resourceNames:
+  - metallb-speaker
+  resources:
+  - securitycontextconstraints
+  verbs:
+  - create
+  - patch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -5622,7 +5631,7 @@ rules:
 - apiGroups:
   - security.openshift.io
   resourceNames:
-  - privileged
+  - metallb-speaker
   resources:
   - securitycontextconstraints
   verbs:

--- a/bundle/manifests/metallb-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/metallb-operator.clusterserviceversion.yaml
@@ -432,7 +432,7 @@ metadata:
     categories: Networking
     certified: "false"
     containerImage: quay.io/metallb/metallb-operator
-    createdAt: "2026-06-30T06:37:39Z"
+    createdAt: "2026-07-28T06:35:36Z"
     description: An operator for deploying MetalLB on a kubernetes cluster.
     operators.operatorframework.io/builder: operator-sdk-v1.40.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
@@ -817,6 +817,15 @@ spec:
                 - patch
                 - update
                 - watch
+            - apiGroups:
+                - security.openshift.io
+              resourceNames:
+                - metallb-speaker
+              resources:
+                - securitycontextconstraints
+              verbs:
+                - create
+                - patch
           serviceAccountName: manager-account
         - rules:
             - apiGroups:
@@ -1410,7 +1419,7 @@ spec:
             - apiGroups:
                 - security.openshift.io
               resourceNames:
-                - privileged
+                - metallb-speaker
               resources:
                 - securitycontextconstraints
               verbs:

--- a/config/metallb_rbac/metallb-openshift.yaml
+++ b/config/metallb_rbac/metallb-openshift.yaml
@@ -177,7 +177,7 @@ rules:
   - apiGroups:
       - security.openshift.io
     resourceNames:
-      - privileged
+      - metallb-speaker
     resources:
       - securitycontextconstraints
     verbs:

--- a/config/metallb_rbac/speaker_role_binding.yaml
+++ b/config/metallb_rbac/speaker_role_binding.yaml
@@ -7,7 +7,7 @@ rules:
   - apiGroups:
       - security.openshift.io
     resourceNames:
-      - privileged
+      - metallb-speaker
     resources:
       - securitycontextconstraints
     verbs:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -122,6 +122,15 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - security.openshift.io
+  resourceNames:
+  - metallb-speaker
+  resources:
+  - securitycontextconstraints
+  verbs:
+  - create
+  - patch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role

--- a/controllers/metallb_controller.go
+++ b/controllers/metallb_controller.go
@@ -81,6 +81,7 @@ var EmbeddedFRRK8sSupportNotAvailable = errors.New("current CNO version does not
 // +kubebuilder:rbac:groups=admissionregistration.k8s.io,resources=validatingwebhookconfigurations,verbs=create;delete;get;update;patch;list;watch
 // +kubebuilder:rbac:groups="",resources=secrets,verbs=create;delete;get;update;patch;list;watch
 // +kubebuilder:rbac:groups=operator.openshift.io,resources=networks,verbs=get;list;watch;update;
+// +kubebuilder:rbac:groups=security.openshift.io,resources=securitycontextconstraints,resourceNames=metallb-speaker,verbs=create;patch
 // +kubebuilder:rbac:groups=config.openshift.io,resources=apiservers;clusteroperators,verbs=get;list;watch;
 
 func (r *MetalLBReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {

--- a/hack/ocp-kustomize-overlay/rbac.yaml
+++ b/hack/ocp-kustomize-overlay/rbac.yaml
@@ -22,10 +22,32 @@ roleRef:
   name: allow-privileged
 subjects:
   - kind: ServiceAccount
-    name: speaker
-    namespace: metallb-system
-  - kind: ServiceAccount
     name: frr-k8s-daemon
     namespace: metallb-system
 ---
-
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: metallb-speaker-scc
+rules:
+  - apiGroups:
+      - security.openshift.io
+    resourceNames:
+      - metallb-speaker
+    resources:
+      - securitycontextconstraints
+    verbs:
+      - use
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: metallb-speaker-scc
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: metallb-speaker-scc
+subjects:
+  - kind: ServiceAccount
+    name: speaker
+    namespace: metallb-system

--- a/pkg/helm/config.go
+++ b/pkg/helm/config.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 
 	metallbv1beta1 "github.com/metallb/metallb-operator/api/v1beta1"
+	"github.com/metallb/metallb-operator/pkg/openshift"
 	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/util/yaml"
@@ -115,6 +116,18 @@ func ocpServiceMonitorTLSConfig(component, namespace string) map[string]interfac
 		"keyFile":            "/etc/prometheus/secrets/metrics-client-certs/tls.key",
 		"insecureSkipVerify": false,
 	}
+}
+
+func setRequiredSCCAnnotationForSpeaker(obj *unstructured.Unstructured) error {
+	annotations, _, err := unstructured.NestedStringMap(obj.Object, "spec", "template", "metadata", "annotations")
+	if err != nil {
+		return err
+	}
+	if annotations == nil {
+		annotations = make(map[string]string)
+	}
+	annotations["openshift.io/required-scc"] = openshift.SpeakerSCCName
+	return unstructured.SetNestedStringMap(obj.Object, annotations, "spec", "template", "metadata", "annotations")
 }
 
 func updateAnnotations(obj *unstructured.Unstructured, annotations map[string]string) error {

--- a/pkg/helm/metallb.go
+++ b/pkg/helm/metallb.go
@@ -18,6 +18,7 @@ package helm
 
 import (
 	metallbv1beta1 "github.com/metallb/metallb-operator/api/v1beta1"
+	"github.com/metallb/metallb-operator/pkg/openshift"
 	"github.com/metallb/metallb-operator/pkg/params"
 	"helm.sh/helm/v3/pkg/action"
 	"helm.sh/helm/v3/pkg/chart"
@@ -86,12 +87,20 @@ func (h *MetalLBChart) Objects(envConfig params.EnvConfig, crdConfig *metallbv1b
 				return nil, err
 			}
 		}
+		if isSpeakerDaemonSet(obj) && envConfig.IsOpenshift {
+			if err := setRequiredSCCAnnotationForSpeaker(obj); err != nil {
+				return nil, err
+			}
+		}
 		if isServiceMonitor(obj) && envConfig.IsOpenshift {
 			err := setOcpMonitorFields(obj)
 			if err != nil {
 				return nil, err
 			}
 		}
+	}
+	if envConfig.IsOpenshift {
+		objs = append(objs, openshift.SpeakerSCC())
 	}
 	return objs, nil
 }

--- a/pkg/helm/metallb_test.go
+++ b/pkg/helm/metallb_test.go
@@ -411,6 +411,64 @@ func TestNetworkPolicies(t *testing.T) {
 	g.Expect(networkPolicyFound).To(BeFalse())
 }
 
+func TestSpeakerSCCOnOpenShift(t *testing.T) {
+	tests := []struct {
+		name        string
+		isOpenshift bool
+		expectSCC   bool
+	}{
+		{"OCP includes SCC and annotation", true, true},
+		{"non-OCP excludes SCC and annotation", false, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+			chart, err := NewMetalLBChart(metalLBChartPath, metalLBChartName, MetalLBTestNameSpace, nil)
+			g.Expect(err).To(BeNil())
+
+			metallb := &metallbv1beta1.MetalLB{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "metallb",
+					Namespace: MetalLBTestNameSpace,
+				},
+			}
+
+			envConfig := defaultEnvConfig
+			envConfig.IsOpenshift = tt.isOpenshift
+
+			objs, err := chart.Objects(envConfig, metallb)
+			g.Expect(err).To(BeNil())
+
+			var sccFound, annotationFound bool
+			for _, obj := range objs {
+				if obj.GetKind() == "SecurityContextConstraints" && obj.GetName() == "metallb-speaker" {
+					sccFound = true
+					hostNet, _, _ := unstructured.NestedBool(obj.Object, "allowHostNetwork")
+					g.Expect(hostNet).To(BeTrue())
+					hostPorts, _, _ := unstructured.NestedBool(obj.Object, "allowHostPorts")
+					g.Expect(hostPorts).To(BeTrue())
+					privEsc, _, _ := unstructured.NestedBool(obj.Object, "allowPrivilegeEscalation")
+					g.Expect(privEsc).To(BeFalse())
+					privContainer, _, _ := unstructured.NestedBool(obj.Object, "allowPrivilegedContainer")
+					g.Expect(privContainer).To(BeFalse())
+					caps, _, _ := unstructured.NestedStringSlice(obj.Object, "allowedCapabilities")
+					g.Expect(caps).To(ConsistOf("NET_RAW"))
+					dropCaps, _, _ := unstructured.NestedStringSlice(obj.Object, "requiredDropCapabilities")
+					g.Expect(dropCaps).To(ConsistOf("ALL"))
+				}
+				if obj.GetKind() == "DaemonSet" && obj.GetName() == "speaker" {
+					ann, _, _ := unstructured.NestedStringMap(obj.Object, "spec", "template", "metadata", "annotations")
+					if ann["openshift.io/required-scc"] == "metallb-speaker" {
+						annotationFound = true
+					}
+				}
+			}
+			g.Expect(sccFound).To(Equal(tt.expectSCC))
+			g.Expect(annotationFound).To(Equal(tt.expectSCC))
+		})
+	}
+}
+
 func validateObject(testcase, name string, obj *unstructured.Unstructured) error {
 	goldenFile := filepath.Join("testdata", testcase+"-"+name+".golden")
 	j, err := json.MarshalIndent(obj, "", "    ")

--- a/pkg/helm/testdata/ocp-metrics-speaker.golden
+++ b/pkg/helm/testdata/ocp-metrics-speaker.golden
@@ -21,6 +21,9 @@
         },
         "template": {
             "metadata": {
+                "annotations": {
+                    "openshift.io/required-scc": "metallb-speaker"
+                },
                 "labels": {
                     "app": "metallb",
                     "component": "speaker"

--- a/pkg/openshift/scc.go
+++ b/pkg/openshift/scc.go
@@ -1,0 +1,59 @@
+package openshift
+
+import (
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+const SpeakerSCCName = "metallb-speaker"
+
+func SpeakerSCC() *unstructured.Unstructured {
+	return &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "security.openshift.io/v1",
+			"kind":       "SecurityContextConstraints",
+			"metadata": map[string]interface{}{
+				"name": SpeakerSCCName,
+				"annotations": map[string]interface{}{
+					"kubernetes.io/description": "Custom SCC for MetalLB speaker.",
+				},
+			},
+			"allowHostDirVolumePlugin": false,
+			"allowHostIPC":             false,
+			"allowHostNetwork":         true,
+			"allowHostPID":             false,
+			"allowHostPorts":           true,
+			"allowPrivilegeEscalation": false,
+			"allowPrivilegedContainer": false,
+			"allowedCapabilities": []interface{}{
+				"NET_RAW",
+			},
+			"defaultAddCapabilities": []interface{}{},
+			"fsGroup": map[string]interface{}{
+				"type": "RunAsAny",
+			},
+			"readOnlyRootFilesystem": false,
+			"requiredDropCapabilities": []interface{}{
+				"ALL",
+			},
+			"runAsUser": map[string]interface{}{
+				"type": "RunAsAny",
+			},
+			"seLinuxContext": map[string]interface{}{
+				"type": "RunAsAny",
+			},
+			"supplementalGroups": map[string]interface{}{
+				"type": "RunAsAny",
+			},
+			"volumes": []interface{}{
+				"configMap",
+				"downwardAPI",
+				"emptyDir",
+				"projected",
+				"secret",
+			},
+			"users":    []interface{}{},
+			"groups":   []interface{}{},
+			"priority": nil,
+		},
+	}
+}


### PR DESCRIPTION
Replace usage of the privileged SCC for MetalLB speaker with a purpose-built SCC that grants only the capabilities the speaker actually needs (NET_RAW) and host networking, without granting full privileged access.

The operator now creates the metallb-speaker SCC during reconciliation on OpenShift and annotates speaker pods with openshift.io/required-scc to explicitly request it.

<!-- Thanks for sending a pull request!
1. If this is your first time, please read the [contributing guide](https://metallb.universe.tf/community/#contributing)
2. For non-trivial pull requests, please [file an
   issue](https://github.com/metallb/metallb-operator/issues/new) first, and get
   agreement that the change is a good idea, and a general guideline
   for how it should be implemented, before sending code. Large PRs
   that weren't first discussed and agreed upon in an issue won't be
   accepted.
3. If the PR fixes a particular bug, please include the words "Fixed
   #<issue number>" in the PR text, so that the bug auto-closes when
   the PR is merged.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
> /kind bug
> /kind cleanup
/kind feature
> /kind design
> /kind flake
> /kind failing
> /kind documentation
> /kind regression

**What this PR does / why we need it**:

**Special notes for your reviewer**:
verified in https://github.com/openshift/metallb-operator/pull/336
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
